### PR TITLE
Speed up list_available

### DIFF
--- a/mamba_gator/envmanager.py
+++ b/mamba_gator/envmanager.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2016-2020 Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import asyncio
+import collections
 import json
 import logging
 import os
@@ -608,13 +609,11 @@ class EnvManager:
             of "conda search --json".
             """
 
-            data_ = {}
+            data_ = collections.defaultdict(lambda : [])
             for entry in data['result']['pkgs']:
                 name = entry.get('name')
-                if name in data_.keys():
+                if name is not None:
                     data_[name].append(entry)
-                else:
-                    data_[name] = [entry]
 
             return data_
 

--- a/mamba_gator/tests/test_api.py
+++ b/mamba_gator/tests/test_api.py
@@ -5,6 +5,7 @@ import os
 import sys
 import unittest
 import unittest.mock as mock
+from itertools import chain
 
 try:
     from unittest.mock import AsyncMock
@@ -971,6 +972,14 @@ class TestPackagesHandler(JupyterCondaAPITest):
                     "ssl_verify": False,
                 }
 
+                if has_mamba:
+                    # Change dummy to match mamba repoquery format
+                    dummy = {
+                        "result": {
+                            "pkgs": list(chain(*dummy.values()))
+                        }
+                    }
+
                 rvalue = [
                     (0, json.dumps(dummy)),
                     (0, json.dumps(channels)),
@@ -984,6 +993,13 @@ class TestPackagesHandler(JupyterCondaAPITest):
 
                 r = self.wait_for_task(self.conda_api.get, ["packages"])
                 self.assertEqual(r.status_code, 200)
+
+                args, _ = f.call_args_list[0]
+                if has_mamba:
+                    self.assertSequenceEqual(args[1:], ["repoquery", "search", "*", "--json"])
+                else:
+                    self.assertSequenceEqual(args[1:], ["search", "--json"])
+
                 body = r.json()
 
                 expected = {
@@ -1164,6 +1180,14 @@ class TestPackagesHandler(JupyterCondaAPITest):
                     ],
                 }
 
+                if has_mamba:
+                    # Change dummy to match mamba repoquery format
+                    dummy = {
+                        "result": {
+                            "pkgs": list(chain(*dummy.values()))
+                        }
+                    }
+
                 with tempfile.TemporaryDirectory() as local_channel:
                     with open(
                         os.path.join(local_channel, "channeldata.json"), "w+"
@@ -1202,6 +1226,13 @@ class TestPackagesHandler(JupyterCondaAPITest):
 
                     r = self.wait_for_task(self.conda_api.get, ["packages"])
                     self.assertEqual(r.status_code, 200)
+
+                    args, _ = f.call_args_list[0]
+                    if has_mamba:
+                        self.assertSequenceEqual(args[1:], ["repoquery", "search", "*", "--json"])
+                    else:
+                        self.assertSequenceEqual(args[1:], ["search", "--json"])
+
                     body = r.json()
 
                     expected = {
@@ -1382,6 +1413,14 @@ class TestPackagesHandler(JupyterCondaAPITest):
                     ],
                 }
 
+                if has_mamba:
+                    # Change dummy to match mamba repoquery format
+                    dummy = {
+                        "result": {
+                            "pkgs": list(chain(*dummy.values()))
+                        }
+                    }
+
                 with tempfile.TemporaryDirectory() as local_channel:
                     local_name = local_channel.strip("/")
                     channels = {
@@ -1414,6 +1453,13 @@ class TestPackagesHandler(JupyterCondaAPITest):
 
                     r = self.wait_for_task(self.conda_api.get, ["packages"])
                     self.assertEqual(r.status_code, 200)
+
+                    args, _ = f.call_args_list[0]
+                    if has_mamba:
+                        self.assertSequenceEqual(args[1:], ["repoquery", "search", "*", "--json"])
+                    else:
+                        self.assertSequenceEqual(args[1:], ["search", "--json"])
+
                     body = r.json()
 
                     expected = {
@@ -1620,6 +1666,15 @@ class TestPackagesHandler(JupyterCondaAPITest):
                     "ssl_verify": False,
                 }
 
+
+                if has_mamba:
+                    # Change dummy to match mamba repoquery format
+                    dummy = {
+                        "result": {
+                            "pkgs": list(chain(*dummy.values()))
+                        }
+                    }
+
                 rvalue = [
                     (0, json.dumps(dummy)),
                     (0, json.dumps(channels)),
@@ -1634,6 +1689,12 @@ class TestPackagesHandler(JupyterCondaAPITest):
                 # First retrival no cache available
                 r = self.wait_for_task(self.conda_api.get, ["packages"])
                 self.assertEqual(r.status_code, 200)
+
+                args, _ = f.call_args_list[0]
+                if has_mamba:
+                    self.assertSequenceEqual(args[1:], ["repoquery", "search", "*", "--json"])
+                else:
+                    self.assertSequenceEqual(args[1:], ["search", "--json"])
 
                 expected = {
                     "packages": [


### PR DESCRIPTION
As discussed in https://github.com/mamba-org/gator/issues/132 and https://github.com/mamba-org/mamba/issues/835, use `mamba repoquery search "*" --json` in favour of `mamba search --json` (or `conda search --json`), since the later is significantly slower than `mamba repoquery`.