### PR TITLE
Create conda store environment

### DIFF
--- a/packages/conda-store/package.json
+++ b/packages/conda-store/package.json
@@ -41,7 +41,8 @@
   "dependencies": {
     "@jupyterlab/application": "^3.1.0",
     "@jupyterlab/settingregistry": "^3.1.0",
-    "@mamba-org/gator-common": "^3.0.2"
+    "@mamba-org/gator-common": "^3.0.2",
+    "yaml": "^1.10.2"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/conda-store/src/condaStore.ts
+++ b/packages/conda-store/src/condaStore.ts
@@ -1,3 +1,5 @@
+import { stringify } from 'yaml';
+
 export interface ICondaStoreEnvironment {
   name: string;
   build_id: number;
@@ -222,4 +224,55 @@ export async function fetchChannels(
     return await response.json();
   }
   return [];
+}
+
+/**
+ * Create a new environment from a specification.
+ *
+ * @async
+ * @param {string} namespace - Namespace for the environment
+ * @param {string} specification - YAML-formatted specification containing environment name and
+ * dependencies
+ * @returns {Promise<Response>}
+ */
+export async function specifyEnvironment(
+  baseUrl: string,
+  namespace: string,
+  specification: string
+): Promise<Response> {
+  return await fetch(`${getServerUrl(baseUrl)}/specification/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      namespace: namespace,
+      specification
+    })
+  });
+}
+
+/**
+ * Create a new environment from a list of package names.
+ *
+ * @async
+ * @param {string} baseUrl - Base URL of the conda-store server; usually http://localhost:5000
+ * @param {string} namespace - Namespace into which the environment is to be created.
+ * @param {string} environment - Name of the new environment.
+ * @param {Array<string>} dependencies - List of string package names to be added to the spec.
+ * @returns {Promise<void>}
+ */
+export async function createEnvironment(
+  baseUrl: string,
+  namespace: string,
+  environment: string,
+  dependencies: Array<string>
+): Promise<void> {
+  await specifyEnvironment(
+    baseUrl,
+    namespace,
+    stringify({
+      name: environment,
+      dependencies
+    })
+  );
+  return;
 }

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -16,6 +16,7 @@
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "preserveWatchOutput": true,
+    "pretty": true,
     "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12475,6 +12475,11 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yaml@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
 yargs-parser@20.x, yargs-parser@^20.2.3:
   version "20.2.4"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"


### PR DESCRIPTION
## Summary
This PR adds support for creating conda-store environments.

## Changes
* Added ability to create conda-store environments.
* Move the `parseEnvironment` function out of the `CondaStorePackageManager` - it's used by the `CondaStoreEnvironmentManager` as well, and doesn't need to be part of the class.
* Fixed issue where not all packages were being shown if there was either no installed or no available packages.
* Added `async` to the rest of the empty `CondaStoreEnvironmentManager` functions which should have had that keyword from before.
* Made the output of `tsc` use the `pretty` format - it's much easier to spot compilation errors in the terminal with this setting