### PR TITLE
Add ability to export conda-store environment

### DIFF
--- a/packages/conda-store/src/condaStore.ts
+++ b/packages/conda-store/src/condaStore.ts
@@ -319,3 +319,29 @@ export async function removePackages(
   await createEnvironment(baseUrl, namespace, environment, dependencies);
   return;
 }
+
+/**
+ * Export an environment as a yaml file.
+ *
+ * @async
+ * @param {string} baseUrl - Base URL of the conda-store server; usually http://localhost:5000
+ * @param {string} namespace - Namespace of the environment to be exported
+ * @param {string} environment - Name of the environment
+ * @returns {Promise<Response>} Response containing the yaml of the environment specification
+ * in the response text
+ */
+export async function exportEnvironment(
+  baseUrl: string,
+  namespace: string,
+  environment: string
+): Promise<Response> {
+  // First get the build ID of the requested environment
+  const response = await fetch(
+    `${getServerUrl(baseUrl)}/environment/${namespace}/${environment}/`
+  );
+
+  const { data } = await response.json();
+  return await fetch(
+    `${getServerUrl(baseUrl)}/build/${data.current_build_id}/yaml/`
+  );
+}

--- a/packages/conda-store/src/condaStoreEnvironmentManager.ts
+++ b/packages/conda-store/src/condaStoreEnvironmentManager.ts
@@ -9,7 +9,8 @@ import {
   condaStoreServerStatus,
   createEnvironment,
   specifyEnvironment,
-  removePackages
+  removePackages,
+  exportEnvironment
 } from './condaStore';
 
 interface IParsedEnvironment {
@@ -116,8 +117,17 @@ export class CondaStoreEnvironmentManager implements IEnvironmentManager {
     return this._environmentChanged;
   }
 
+  /**
+   * Export the selected conda-store environment as a YAML file.
+   *
+   * @async
+   * @param {string} name - <namespace>/<environment> name for the new environment.
+   * @param {boolean} [fromHistory] - Unused here; kept for compatibility
+   * @returns {Promise<Response>} Response with text attribute containing the requested environment yaml
+   */
   async export(name: string, fromHistory?: boolean): Promise<Response> {
-    return;
+    const { namespace, environment } = parseEnvironment(name);
+    return await exportEnvironment(this._baseUrl, namespace, environment);
   }
 
   /**


### PR DESCRIPTION
## Summary
This PR adds the ability to export a conda-store environment as a yaml file.

## Changes
* Added a new function to export conda-store environments, and called it from the `CondaStoreEnvironmentManager`.