### PR TITLE
Add ability to remove conda-store packages

### DIFF
--- a/packages/conda-store/src/condaStoreEnvironmentManager.ts
+++ b/packages/conda-store/src/condaStoreEnvironmentManager.ts
@@ -8,7 +8,8 @@ import {
   ICondaStorePackage,
   condaStoreServerStatus,
   createEnvironment,
-  specifyEnvironment
+  specifyEnvironment,
+  removePackages
 } from './condaStore';
 
 interface IParsedEnvironment {
@@ -574,8 +575,16 @@ export class CondaStorePackageManager implements Conda.IPackageManager {
     return Promise.resolve(void 0);
   }
 
+  /**
+   * Remove packages from an environment.
+   *
+   * @async
+   * @param {Array<string>} packages - Packages to remove from the environment
+   * @param {string} [environment] - Namespace/environment ti be modified
+   */
   async remove(packages: Array<string>, environment?: string): Promise<void> {
-    return Promise.resolve(void 0);
+    const { namespace, environment: envName } = parseEnvironment(environment);
+    await removePackages(this.baseUrl, namespace, envName, packages);
   }
 
   async getDependencies(


### PR DESCRIPTION
## Summary
This PR adds the ability to remove packages from a conda-store environment.

## Changes
* Added a function which removes packages from the currently selected environment. Conda-store handles environment changes differently from regular conda; instead of modifying an environment, a new _build_ (i.e. new environment) is created which includes the requested modifications. To achieve this, the new functions introduced in this PR do the following:

1. Query the conda-store server to gather all the installed packages of the environment
2. Remove the requested packages from the list of installed packages to create a new package list
3. Submit a new build specification with the new package list

Note that changes to the environment take a little time to be digested by the conda-store server, so deleted packages may persist for a little while until the build completes. Once the build finishes, the removed packages will be displayed correctly when the package list is refreshed.