### PR TITLE
Replace react-cool-inview onChange with onEnter

### DIFF
--- a/packages/common/src/components/CondaPkgList.tsx
+++ b/packages/common/src/components/CondaPkgList.tsx
@@ -84,12 +84,10 @@ export function CondaPkgList({
 }): JSX.Element {
   const { observe } = useInView({
     rootMargin: '200px 0px',
-    onChange: async ({ inView, unobserve, observe }) => {
-      if (inView) {
-        unobserve();
-        await onPkgBottomHit();
-        observe();
-      }
+    onEnter: async ({ unobserve, observe }) => {
+      unobserve();
+      await onPkgBottomHit();
+      observe();
     }
   });
   return (


### PR DESCRIPTION
I observed that onChange fires repeatedly if the observed element
is in view, whereas onEnter only fires once