### PR TITLE
Add ability to add conda-store packages

### DIFF
--- a/packages/common/src/components/CondaPkgPanel.tsx
+++ b/packages/common/src/components/CondaPkgPanel.tsx
@@ -174,40 +174,36 @@ export class CondaPkgPanel extends React.Component<
       return;
     }
 
-    const selectIdx = this.state.selected.indexOf(pkg);
-    const selection = this.state.selected;
-    if (selectIdx >= 0) {
-      this.state.selected.splice(selectIdx, 1);
-    }
+    let selection: Array<Conda.IPackage> = this.state.selected
 
-    if (pkg.version_installed) {
-      if (pkg.version_installed === pkg.version_selected) {
-        if (pkg.updatable) {
-          pkg.version_selected = ''; // Set for update
-          selection.push(pkg);
-        } else {
-          pkg.version_selected = 'none'; // Set for removal
-          selection.push(pkg);
-        }
-      } else {
-        if (pkg.version_selected === 'none') {
-          pkg.version_selected = pkg.version_installed;
-        } else {
-          pkg.version_selected = 'none'; // Set for removal
-          selection.push(pkg);
-        }
-      }
+    // If the clicked package was already selected, deselect it; otherwise add it to the selected
+    // packages
+    if (this.state.selected.some(({name}) => name === pkg.name)) {
+        selection = selection.filter(({name}) => name !== pkg.name)
     } else {
-      if (pkg.version_selected !== 'none') {
-        pkg.version_selected = 'none'; // Unselect
-      } else {
-        pkg.version_selected = ''; // Select 'Any'
-        selection.push(pkg);
-      }
+        if (pkg.version_installed) {
+          if (pkg.version_installed === pkg.version_selected) {
+            pkg.version_selected = pkg.updatable ? '' : 'none';
+            selection.push(pkg);
+          } else {
+            if (pkg.version_selected === 'none') {
+              pkg.version_selected = pkg.version_installed;
+            } else {
+              pkg.version_selected = 'none'; // Set for removal
+              selection.push(pkg);
+            }
+          }
+        } else {
+          if (pkg.version_selected !== 'none') {
+            pkg.version_selected = 'none'; // Unselect
+          } else {
+            pkg.version_selected = ''; // Select 'Any'
+            selection.push(pkg);
+          }
+        }
     }
 
     this.setState({
-      packages: this.state.packages,
       selected: selection
     });
   }
@@ -217,11 +213,7 @@ export class CondaPkgPanel extends React.Component<
       return;
     }
 
-    const selectIdx = this.state.selected.indexOf(pkg);
-    const selection = this.state.selected;
-    if (selectIdx >= 0) {
-      this.state.selected.splice(selectIdx, 1);
-    }
+    let selection = this.state.selected.filter(({name}) => name !== pkg.name)
 
     if (pkg.version_installed) {
       if (pkg.version_installed !== version) {
@@ -236,7 +228,6 @@ export class CondaPkgPanel extends React.Component<
     pkg.version_selected = version;
 
     this.setState({
-      packages: this.state.packages,
       selected: selection
     });
   }
@@ -430,13 +421,6 @@ export class CondaPkgPanel extends React.Component<
       return;
     }
 
-    this.state.selected.forEach(
-      pkg =>
-        (pkg.version_selected = pkg.version_installed
-          ? pkg.version_installed
-          : 'none')
-    );
-
     this.setState({
       selected: []
     });
@@ -458,6 +442,26 @@ export class CondaPkgPanel extends React.Component<
       this._currentEnvironment = this.props.packageManager.environment;
       this._updatePackages();
     }
+  }
+
+  combinePackagesSelected(packages: Array<Conda.IPackage>, selected: Array<Conda.IPackage>): Array<Conda.IPackage> {
+    // Update the selected state of each package. Generate a hashmap for the lookup; then update
+    // each of the new packages with info from the list of selected packages; then convert back
+    // to an array to update state.
+    const packageMap = new Map(packages.map(pkg => [pkg.name, pkg]))
+    selected.forEach(({name, version_installed, version_selected}) => {
+        if (packageMap.has(name)) {
+            packageMap.set(
+                name,
+                {...packageMap.get(name), version_installed, version_selected}
+            )
+        }
+    })
+    const combined: Array<Conda.IPackage> = []
+    packageMap.forEach(pkg => {
+        combined.push(pkg)
+    })
+    return combined
   }
 
   /**
@@ -484,19 +488,15 @@ export class CondaPkgPanel extends React.Component<
   }
 
   render(): JSX.Element {
-    let filteredPkgs: Conda.IPackage[] = [];
-    if (this.state.activeFilter === PkgFilters.All) {
-      filteredPkgs = this.state.packages;
-    } else if (this.state.activeFilter === PkgFilters.Installed) {
-      filteredPkgs = this.state.packages.filter(pkg => pkg.version_installed);
+    let filteredPkgs = this.combinePackagesSelected(this.state.packages, this.state.selected);
+    if (this.state.activeFilter === PkgFilters.Installed) {
+      filteredPkgs = filteredPkgs.filter(pkg => pkg.version_installed);
     } else if (this.state.activeFilter === PkgFilters.Available) {
-      filteredPkgs = this.state.packages.filter(pkg => !pkg.version_installed);
+      filteredPkgs = filteredPkgs.filter(pkg => !pkg.version_installed);
     } else if (this.state.activeFilter === PkgFilters.Updatable) {
-      filteredPkgs = this.state.packages.filter(pkg => pkg.updatable);
+      filteredPkgs = filteredPkgs.filter(pkg => pkg.updatable);
     } else if (this.state.activeFilter === PkgFilters.Selected) {
-      filteredPkgs = this.state.packages.filter(
-        pkg => this.state.selected.indexOf(pkg) >= 0
-      );
+      filteredPkgs = this.state.selected
     }
 
     let searchPkgs: Conda.IPackage[] = [];

--- a/packages/conda-store/src/condaStoreEnvironmentManager.ts
+++ b/packages/conda-store/src/condaStoreEnvironmentManager.ts
@@ -10,7 +10,8 @@ import {
   createEnvironment,
   specifyEnvironment,
   removePackages,
-  exportEnvironment
+  exportEnvironment,
+  addPackages
 } from './condaStore';
 
 interface IParsedEnvironment {
@@ -569,8 +570,20 @@ export class CondaStorePackageManager implements Conda.IPackageManager {
     return true;
   }
 
+  /**
+   * Add packages to an environment.
+   *
+   * @async
+   * @param {Array<string>} packages - Packages to add.
+   * @param {string} [environment] - Environment for which packages are to be added.
+   * @returns {Promise<void>}
+   */
   async install(packages: Array<string>, environment?: string): Promise<void> {
-    return Promise.resolve(void 0);
+    const { namespace, environment: environmentName } = parseEnvironment(
+      environment === undefined ? this.environment : environment
+    );
+    await addPackages(this.baseUrl, namespace, environmentName, packages);
+    return;
   }
 
   async develop(path: string, environment?: string): Promise<void> {


### PR DESCRIPTION
## Summary
This PR adds the ability to add conda-store packages.

## Changes
* Created new function to add a list of packages to an environment; if a package already exists in the environment, no change is made to that package.


Not sure about the CI failures - they look like an unrelated build issue.