### PR TITLE
feat: remove conda-store environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Finally, start up conda-store with Docker:
 
 ```bash
 cd conda-store/examples/docker/
-docker-compose up --build
+docker compose up --build
 ```
 
 This will start the conda-store server inside a docker container at

--- a/packages/conda-store/src/condaStore.ts
+++ b/packages/conda-store/src/condaStore.ts
@@ -1,3 +1,9 @@
+/**
+ * @file Client-side functions to call the conda-store REST API.
+ *
+ * Note: fetch is assumed to be global (execution environment: web browser).
+ */
+
 import { stringify } from 'yaml';
 
 export interface ICondaStoreEnvironment {
@@ -271,6 +277,29 @@ export async function createEnvironment(
       name: environment,
       dependencies
     })
+  );
+  return;
+}
+
+/**
+ * Remove an environment.
+ *
+ * @async
+ * @param {string} baseUrl - Base URL of the conda-store server; usually http://localhost:5000
+ * @param {string} namespace - Namespace the environment belongs to.
+ * @param {string} environment - Name of the environment.
+ * @returns {Promise<void>}
+ */
+export async function removeEnvironment(
+  baseUrl: string,
+  namespace: string,
+  environment: string
+): Promise<void> {
+  await fetch(
+    `${getServerUrl(baseUrl)}/environment/${namespace}/${environment}/`,
+    {
+      method: 'DELETE'
+    }
   );
   return;
 }

--- a/packages/conda-store/src/condaStoreEnvironmentManager.ts
+++ b/packages/conda-store/src/condaStoreEnvironmentManager.ts
@@ -10,7 +10,8 @@ import {
   createEnvironment,
   specifyEnvironment,
   removePackages,
-  exportEnvironment
+  exportEnvironment,
+  removeEnvironment
 } from './condaStore';
 
 interface IParsedEnvironment {
@@ -94,6 +95,7 @@ export class CondaStoreEnvironmentManager implements IEnvironmentManager {
   /**
    * Create a new environment.
    *
+   * @async
    * @param {string} name - <namespace>/<environment> name for the new environment.
    * @param {string} [type] - Type of environment to create; see this.environmentTypes for possible
    * values.
@@ -158,7 +160,15 @@ export class CondaStoreEnvironmentManager implements IEnvironmentManager {
     return;
   }
 
+  /**
+   * Remove an environment.
+   *
+   * @async
+   * @param {string} name - <namespace>/<environment> name for environment.
+   */
   async remove(name: string): Promise<void> {
+    const { namespace, environment } = parseEnvironment(name);
+    await removeEnvironment(this._baseUrl, namespace, environment);
     return;
   }
 


### PR DESCRIPTION
Closes Quansight/conda-store#141.

Per [conda-store API docs](https://conda-store.readthedocs.io/en/latest/contributing.html#rest-api).

Note: this PR is against conda-store-integration branch, not the main branch.