### PR TITLE
Fixing the url to be called for api status /api/v1/

### DIFF
--- a/packages/conda-store/src/condaStore.ts
+++ b/packages/conda-store/src/condaStore.ts
@@ -42,7 +42,7 @@ interface IPaginatedResult<T> {
  * @returns {string} Formatted base URL for all conda-store server endpoints
  */
 function getServerUrl(serverURL: string): string {
-  return `${serverURL}/api/v1`;
+  return `${serverURL}/api/v1/`;
 }
 
 /**


### PR DESCRIPTION
For now Conda-Store is using Flask for the web server. It redirects requests that don't correctly match to a close matching
one. E.g. /api/v1 -> /api/v1/. When using https this results in a CORS error. Here is the url that is set in conda-store https://github.com/Quansight/conda-store/blob/main/conda-store-server/conda_store_server/server/views/api.py#L99.

![image](https://user-images.githubusercontent.com/1740337/153510806-7793b5e5-ba69-4e3c-bcb8-e8be1d17691b.png)
