### PR TITLE
Load first environment if none is_default

### DIFF
--- a/packages/common/src/components/NbConda.tsx
+++ b/packages/common/src/components/NbConda.tsx
@@ -363,11 +363,11 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
           environments: await this.props.model.environments
         };
         if (this.state.currentEnvironment === undefined) {
-          newState.environments.forEach(env => {
-            if (env.is_default) {
-              newState.currentEnvironment = env.name;
-            }
-          });
+          const defaultEnvironment =
+            newState.environments.find(env => env.is_default) ||
+            // in case no environment is_default just load the first environment
+            newState.environments[0];
+          newState.currentEnvironment = defaultEnvironment.name;
           newState.channels = await this.props.model.getChannels(
             newState.currentEnvironment
           );


### PR DESCRIPTION
But instead of hiding the package panel, I think it makes more sense (for consistency) to make sure that we pick __some__ environment to load.

Step towards closing https://github.com/Quansight/conda-store/issues/240.