### PR TITLE
In Conda Store, hide filter and show installed 

### DIFF
--- a/packages/common/src/components/CondaPkgPanel.tsx
+++ b/packages/common/src/components/CondaPkgPanel.tsx
@@ -472,7 +472,7 @@ export class CondaPkgPanel extends React.Component<
       this.setState({
         isLoading: true
       });
-      const packages = await this._model.loadInstalledPackages?.();
+      const packages = await this._model.getInstalledPackages?.();
       if (packages !== undefined) {
         this.setState({ packages });
       }
@@ -528,10 +528,7 @@ export class CondaPkgPanel extends React.Component<
           onApply={this.handleApply}
           onCancel={this.handleCancel}
           onRefreshPackages={this.handleRefreshPackages}
-          filterDisabled={Boolean(
-            // code smell: duck typing
-            this._model.loadInstalledPackages
-          )}
+          filterDisabled={this._model.hasSearchProvider}
         />
         <CondaPkgList
           height={this.props.height - PACKAGE_TOOLBAR_HEIGHT}

--- a/packages/common/src/components/CondaPkgPanel.tsx
+++ b/packages/common/src/components/CondaPkgPanel.tsx
@@ -472,7 +472,7 @@ export class CondaPkgPanel extends React.Component<
       this.setState({
         isLoading: true
       });
-      const packages = await this._model.loadMorePackages?.();
+      const packages = await this._model.loadInstalledPackages?.();
       if (packages !== undefined) {
         this.setState({ packages });
       }
@@ -530,7 +530,7 @@ export class CondaPkgPanel extends React.Component<
           onRefreshPackages={this.handleRefreshPackages}
           filterDisabled={Boolean(
             // code smell: duck typing
-            this._model.loadMorePackages
+            this._model.loadInstalledPackages
           )}
         />
         <CondaPkgList

--- a/packages/common/src/components/CondaPkgPanel.tsx
+++ b/packages/common/src/components/CondaPkgPanel.tsx
@@ -528,6 +528,10 @@ export class CondaPkgPanel extends React.Component<
           onApply={this.handleApply}
           onCancel={this.handleCancel}
           onRefreshPackages={this.handleRefreshPackages}
+          filterDisabled={Boolean(
+            // code smell: duck typing
+            this._model.loadMorePackages
+          )}
         />
         <CondaPkgList
           height={this.props.height - PACKAGE_TOOLBAR_HEIGHT}

--- a/packages/common/src/components/CondaPkgToolBar.tsx
+++ b/packages/common/src/components/CondaPkgToolBar.tsx
@@ -63,24 +63,31 @@ export interface ICondaPkgToolBarProps {
    * Refresh available packages handler
    */
   onRefreshPackages: () => void;
+  /**
+   * Disable the filter dropdown (install, not installed, etc.)
+   * For Conda Store
+   */
+  filterDisabled: boolean;
 }
 
 export const CondaPkgToolBar = (props: ICondaPkgToolBarProps): JSX.Element => {
   return (
     <div className={`lm-Widget ${CONDA_PACKAGES_TOOLBAR_CLASS} jp-Toolbar`}>
-      <div className="lm-Widget jp-Toolbar-item">
-        <HTMLSelect
-          value={props.category}
-          onChange={props.onCategoryChanged}
-          aria-label="Package filter"
-        >
-          <option value={PkgFilters.All}>All</option>
-          <option value={PkgFilters.Installed}>Installed</option>
-          <option value={PkgFilters.Available}>Not installed</option>
-          <option value={PkgFilters.Updatable}>Updatable</option>
-          <option value={PkgFilters.Selected}>Selected</option>
-        </HTMLSelect>
-      </div>
+      {!props.filterDisabled && (
+        <div className="lm-Widget jp-Toolbar-item">
+          <HTMLSelect
+            value={props.category}
+            onChange={props.onCategoryChanged}
+            aria-label="Package filter"
+          >
+            <option value={PkgFilters.All}>All</option>
+            <option value={PkgFilters.Installed}>Installed</option>
+            <option value={PkgFilters.Available}>Not installed</option>
+            <option value={PkgFilters.Updatable}>Updatable</option>
+            <option value={PkgFilters.Selected}>Selected</option>
+          </HTMLSelect>
+        </div>
+      )}
       <div className="lm-Widget jp-Toolbar-item">
         <div className={classes('jp-NbConda-search-wrapper', Style.Search)}>
           <InputGroup

--- a/packages/common/src/tokens.ts
+++ b/packages/common/src/tokens.ts
@@ -209,13 +209,23 @@ export namespace Conda {
      */
     packageChanged: ISignal<IPackageManager, Conda.IPackageChange>;
     /**
-     * Callback triggered when the user scrolls to the bottom of the package
-     * list. Note this is a stateful method that fetches the next page of
-     * results each time it is called.
+     * Get a list of installed packages.
+     *
+     * For traditional conda model:
+     * - returns all installed packages
+     * - some package fields are empty strings and need to be augmented (e.g.,
+     *   package.summary)
+     *
+     * For Conda Store:
+     * - return next page of installed packages
+     * - includes package metadata, such as package.summary
      */
-    loadInstalledPackages?: (
-      environment?: string
-    ) => Promise<Array<Conda.IPackage>>;
+    getInstalledPackages(environment?: string): Promise<Array<Conda.IPackage>>;
+    /**
+     * Does the model provide a way to get a set of packages based on search
+     * query?
+     */
+    hasSearchProvider: boolean;
   }
 
   /**

--- a/packages/common/src/tokens.ts
+++ b/packages/common/src/tokens.ts
@@ -209,10 +209,13 @@ export namespace Conda {
      */
     packageChanged: ISignal<IPackageManager, Conda.IPackageChange>;
     /**
-     * Callback triggered when the user scrolls to the bottom of the package list.
-     * Optionally loads more packages, if the result is paginated.
+     * Callback triggered when the user scrolls to the bottom of the package
+     * list. Note this is a stateful method that fetches the next page of
+     * results each time it is called.
      */
-    loadMorePackages?: (environment?: string) => Promise<Array<Conda.IPackage>>;
+    loadInstalledPackages?: (
+      environment?: string
+    ) => Promise<Array<Conda.IPackage>>;
   }
 
   /**

--- a/packages/conda-store/src/condaStoreEnvironmentManager.ts
+++ b/packages/conda-store/src/condaStoreEnvironmentManager.ts
@@ -234,6 +234,7 @@ export class CondaStorePackageManager implements Conda.IPackageManager {
   availablePageSize = 100;
   availablePackages: Array<ICondaStorePackage> = [];
   baseUrl = '';
+  hasSearchProvider = true;
 
   constructor(environment?: string) {
     this.environment = environment;
@@ -408,21 +409,19 @@ export class CondaStorePackageManager implements Conda.IPackageManager {
   }
 
   /**
-   * Load the next page of installed packages.
+   * Get the next page of installed packages.
    *
    * @async
    * @param {string} environment - Environment for which the installed packages are to be fetched;
    * if none is provided, the current environment is used.
    * @return {Promise<Array<Conda.IPackage>>} Array of installed conda-store packages.
    */
-  async loadInstalledPackages(
-    environment: string
+  async getInstalledPackages(
+    environment: string = this.environment
   ): Promise<Array<Conda.IPackage>> {
     if (this.hasMoreInstalledPackages) {
       const { environment: envName, namespace: namespaceName } =
-        parseEnvironment(
-          environment !== undefined ? environment : this.environment
-        );
+        parseEnvironment(environment);
       const { count, data } = await fetchEnvironmentPackages(
         this.baseUrl,
         namespaceName,
@@ -482,7 +481,7 @@ export class CondaStorePackageManager implements Conda.IPackageManager {
       (lastInstalled === undefined ||
         this.compareName(lastInstalled, lastAvailable) <= 0)
     ) {
-      await this.loadInstalledPackages(environment);
+      await this.getInstalledPackages(environment);
       lastInstalled = this.installedPackages[this.installedPackages.length - 1];
     }
 

--- a/packages/conda-store/src/condaStoreEnvironmentManager.ts
+++ b/packages/conda-store/src/condaStoreEnvironmentManager.ts
@@ -413,11 +413,11 @@ export class CondaStorePackageManager implements Conda.IPackageManager {
    * @async
    * @param {string} environment - Environment for which the installed packages are to be fetched;
    * if none is provided, the current environment is used.
-   * @return {Promise<Array<ICondaStorePackage>>} Array of installed conda-store packages.
+   * @return {Promise<Array<Conda.IPackage>>} Array of installed conda-store packages.
    */
   async loadInstalledPackages(
     environment: string
-  ): Promise<Array<ICondaStorePackage>> {
+  ): Promise<Array<Conda.IPackage>> {
     if (this.hasMoreInstalledPackages) {
       const { environment: envName, namespace: namespaceName } =
         parseEnvironment(
@@ -434,9 +434,10 @@ export class CondaStorePackageManager implements Conda.IPackageManager {
         count > this.installedPage * this.installedPageSize;
       this.installedPage += 1;
       this.installedPackages = [...this.installedPackages, ...data];
-      return data;
     }
-    return [];
+    const { installed } = this.truncate(this.installedPackages, []);
+    const packages = this.mergeConvert(installed);
+    return packages;
   }
 
   /**


### PR DESCRIPTION
This PR is a stepping stone to a minimum viable user experience for Conda Store: https://github.com/Quansight/conda-store/issues/228

Subsequent PRs will change the search box so that instead of merely filtering down a large list of packages locally, it will use search results returned from the server.