### PR TITLE
Background caching option

### DIFF
--- a/packages/labextension/schema/plugin.json
+++ b/packages/labextension/schema/plugin.json
@@ -4,6 +4,12 @@
   "title": "Conda",
   "description": "Environments and packages manager settings.",
   "properties": {
+    "backgroundCaching": {
+      "type": "boolean",
+      "title": "Background caching",
+      "description": "Whether to cache package list as early as possible in the background.",
+      "default": true
+    },
     "companions": {
       "type": "object",
       "title": "Kernel companions",

--- a/packages/labextension/src/index.ts
+++ b/packages/labextension/src/index.ts
@@ -45,7 +45,7 @@ async function activateCondaEnv(
   const model = new CondaEnvironments(settings);
 
   // Request listing available package as quickly as possible
-  if (settings?.get('backgroundCaching') ?? true) {
+  if (settings?.get('backgroundCaching').composite ?? true) {
     Private.loadPackages(model);
   }
 

--- a/packages/labextension/src/index.ts
+++ b/packages/labextension/src/index.ts
@@ -45,7 +45,9 @@ async function activateCondaEnv(
   const model = new CondaEnvironments(settings);
 
   // Request listing available package as quickly as possible
-  Private.loadPackages(model);
+  if (settings?.get('backgroundCaching') ?? true) {
+    Private.loadPackages(model);
+  }
 
   // Track and restore the widget state
   const tracker = new WidgetTracker<MainAreaWidget<CondaEnvWidget>>({


### PR DESCRIPTION
Related to #188.

This PR adds background caching option `backgroundCaching` to Mamba Gator.
Whether to cache package list as early as possible in the background. Default to `true`.

This complements #42.