### PR TITLE
Fix TypeError with github-script v7 API change

### DIFF
--- a/.github/workflows/binder-on-pr.yml
+++ b/.github/workflows/binder-on-pr.yml
@@ -1,8 +1,6 @@
 # Reference https://mybinder.readthedocs.io/en/latest/howto/gh-actions-badges.html
 name: Binder Badge
-on: 
-  pull_request_target:
-    types: [opened]
+on: pull_request
 
 jobs:
   binder:


### PR DESCRIPTION
This issue was introduced in #227, but didn't fail there because it looks like the Binder workflow is only run on the creation of a PR.