### PR TITLE
Restore pull_request_target for Binder Badge

### DIFF
--- a/.github/workflows/binder-on-pr.yml
+++ b/.github/workflows/binder-on-pr.yml
@@ -1,6 +1,12 @@
 # Reference https://mybinder.readthedocs.io/en/latest/howto/gh-actions-badges.html
 name: Binder Badge
-on: pull_request
+on: 
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   binder:


### PR DESCRIPTION
In #234, I changed the GitHub Actions on logic to pull_request for testing. I thought I then dropped that commit, but it looks like I made a mistake. This PR restores the pull_request_target.