### PR TITLE
Fix Jest deprecation for defining ts-jest in globals

### DIFF
--- a/packages/common/jest.config.js
+++ b/packages/common/jest.config.js
@@ -1,5 +1,4 @@
 const jestJupyterLab = require('@jupyterlab/testutils/lib/jest-config');
-
 const esModules = [
   '@jupyterlab/',
   'lib0',
@@ -7,9 +6,7 @@ const esModules = [
   'y\\-websocket',
   'yjs'
 ].join('|');
-
 const jlabConfig = jestJupyterLab(__dirname);
-
 const {
   moduleFileExtensions,
   moduleNameMapper,
@@ -28,16 +25,16 @@ module.exports = {
   setupFilesAfterEnv,
   setupFiles,
   testPathIgnorePatterns,
-  transform,
+  transform: {
+    ...transform,
+    '^.+\\.tsx?$': ['ts-jest', {
+      tsconfig: 'tsconfig.test.json'
+    }]
+  },
   automock: false,
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts'],
   coverageDirectory: 'coverage',
   coverageReporters: ['lcov', 'text'],
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig.test.json'
-    }
-  },
   testRegex: 'src/.*/.*.spec.ts[x]?$',
   transformIgnorePatterns: [`/node_modules/(?!${esModules}).+`]
 };

--- a/packages/labextension/jest.config.js
+++ b/packages/labextension/jest.config.js
@@ -1,5 +1,4 @@
 const jestJupyterLab = require('@jupyterlab/testutils/lib/jest-config');
-
 const esModules = [
   '@jupyterlab/',
   'lib0',
@@ -7,9 +6,7 @@ const esModules = [
   'y\\-websocket',
   'yjs'
 ].join('|');
-
 const jlabConfig = jestJupyterLab(__dirname);
-
 const {
   moduleFileExtensions,
   moduleNameMapper,
@@ -28,16 +25,16 @@ module.exports = {
   setupFilesAfterEnv,
   setupFiles,
   testPathIgnorePatterns,
-  transform,
+  transform: {
+    ...transform,
+    '^.+\\.tsx?$': ['ts-jest', {
+      tsconfig: 'tsconfig.json'
+    }]
+  },
   automock: false,
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/*.d.ts'],
   coverageDirectory: 'coverage',
   coverageReporters: ['lcov', 'text'],
-  globals: {
-    'ts-jest': {
-      tsConfig: 'tsconfig.json'
-    }
-  },
   testRegex: 'src/.*/.*.spec.ts[x]?$',
   transformIgnorePatterns: [`/node_modules/(?!${esModules}).+`]
 };


### PR DESCRIPTION
Fixes the following warning when running the test suite:

```
ts-jest[ts-jest-transformer] (WARN) Define ts-jest config under globals is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
See more at https://kulshekhar.github.io/ts-jest/docs/getting-started/presets#advanced
```