### PR TITLE
Fix crashes for R- and date-based versions

### DIFF
--- a/mamba_gator/envmanager.py
+++ b/mamba_gator/envmanager.py
@@ -786,7 +786,7 @@ class EnvManager:
                     entry = normalize_pkg_info(entry)
                     if pkg_entry is None:
                         pkg_entry = entry
-                        version = parse_version(entry.get("version", ""))
+                    version = parse_version(entry.get("version", ""))
 
                     if version is None:
                         name = entry.get("name")

--- a/mamba_gator/envmanager.py
+++ b/mamba_gator/envmanager.py
@@ -790,9 +790,9 @@ class EnvManager:
 
                     if version is None:
                         name = entry.get("name")
-                        version = entry.get("version")
-                        self.log.warning(f"Unable to parse version '{version}' of '{name}'")
-                        continue
+                        original_version = entry.get("version")
+                        self.log.warning(f"Unable to parse version '{original_version}' of '{name}'")
+                        version = Version("0.0.0")
 
                     if version not in versions:
                         versions.append(version)

--- a/mamba_gator/envmanager.py
+++ b/mamba_gator/envmanager.py
@@ -6,27 +6,25 @@ import json
 import logging
 import os
 import re
-import subprocess
 import sys
 import tempfile
-from functools import partial, lru_cache
+from functools import lru_cache, partial
 from pathlib import Path
 from subprocess import PIPE, Popen
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import tornado
 from jupyter_client.kernelspec import KernelSpecManager
-
-from packaging.version import parse, InvalidVersion
+from packaging.version import InvalidVersion, Version, parse
 
 try:
     import nb_conda_kernels
 except ImportError:
     nb_conda_kernels = None
 
-from .log import get_logger
 from jupyter_server.utils import url2path, url_path_join
 
+from .log import get_logger
 
 CONDA_EXE = os.environ.get("CONDA_EXE", "conda")  # type: str
 
@@ -90,6 +88,23 @@ def get_env_path(kernel_spec: Dict[str, Any]) -> Optional[str]:
             return match.groups()[0]
 
     return None
+
+
+def parse_version(version: str) -> Optional[Version]:
+    """Handle R-style and year-based versions"""
+    # Convert R package versions like "1.8_4" to "1.8.4"
+    version = version.replace('_', '.')
+
+    # Handle year-based versions like "2023d" -> "2023.4"
+    if re.match(r'^\d{4}[a-z]$', version):
+        letter = version[-1]
+        number = ord(letter) - ord('a') + 1
+        version = f"{version[:-1]}.{number}"
+
+    try:
+        return Version(version)
+    except InvalidVersion:
+        return None
 
 
 class EnvManager:
@@ -683,7 +698,7 @@ class EnvManager:
 
         if "error" not in query:
             for dep in query["result"]["pkgs"]:
-                if type(dep) is dict:
+                if isinstance(dep, dict):
                     deps = dep.get("depends", None)
                     if deps:
                         resp[dep["name"]] = deps
@@ -691,6 +706,7 @@ class EnvManager:
                         resp[dep["name"]] = []
 
         return resp
+
 
     async def list_available(self) -> Dict[str, List[Dict[str, str]]]:
         """List all available packages
@@ -721,9 +737,9 @@ class EnvManager:
             of "conda search --json".
             """
 
-            data_ = collections.defaultdict(lambda : [])
-            for entry in data['result']['pkgs']:
-                name = entry.get('name')
+            data_ = collections.defaultdict(lambda: [])
+            for entry in data["result"]["pkgs"]:
+                name = entry.get("name")
                 if name is not None:
                     data_[name].append(entry)
 
@@ -770,10 +786,9 @@ class EnvManager:
                     entry = normalize_pkg_info(entry)
                     if pkg_entry is None:
                         pkg_entry = entry
+                        version = parse_version(entry.get("version", ""))
 
-                    try:
-                        version = parse(entry.get("version", "")) 
-                    except InvalidVersion:
+                    if version is None:
                         name = entry.get("name")
                         version = entry.get("version")
                         self.log.warning(f"Unable to parse version '{version}' of '{name}'")
@@ -788,21 +803,13 @@ class EnvManager:
                         build_number = entry.get("build_number", 0)
                         if build_number > max_build_numbers[version_idx]:
                             max_build_numbers[version_idx] = build_number
-                            max_build_strings[version_idx] = entry.get(
-                                "build_string", ""
-                            )
+                            max_build_strings[version_idx] = entry.get("build_string", "")
 
-                sorted_versions_idx = sorted(
-                    range(len(versions)), key=versions.__getitem__
-                )
+                sorted_versions_idx = sorted(range(len(versions)), key=versions.__getitem__)
 
                 pkg_entry["version"] = [str(versions[i]) for i in sorted_versions_idx]
-                pkg_entry["build_number"] = [
-                    max_build_numbers[i] for i in sorted_versions_idx
-                ]
-                pkg_entry["build_string"] = [
-                    max_build_strings[i] for i in sorted_versions_idx
-                ]
+                pkg_entry["build_number"] = [max_build_numbers[i] for i in sorted_versions_idx]
+                pkg_entry["build_string"] = [max_build_strings[i] for i in sorted_versions_idx]
 
                 packages.append(pkg_entry)
             return packages

--- a/mamba_gator/tests/test_api.py
+++ b/mamba_gator/tests/test_api.py
@@ -1115,7 +1115,6 @@ class TestPackagesHandler(JupyterCondaAPITest):
                 }
 
                 if has_mamba:
-                    # Change dummy to match mamba repoquery format
                     dummy = {
                         "result": {
                             "pkgs": list(chain(*dummy.values()))
@@ -1131,19 +1130,29 @@ class TestPackagesHandler(JupyterCondaAPITest):
                         )
                     local_name = local_channel.strip("/")
                     channels = {
-                        "channel_alias": {},
-                        "channels": [local_channel],
-                        "custom_multichannels": {},
-                        "custom_channels": {
-                            local_name: {
-                                "auth": None,
-                                "location": "",
-                                "name": local_name,
-                                "package_filename": None,
-                                "platform": None,
-                                "scheme": "file",
-                                "token": None,
-                            }
+                        "channel_alias": {
+                            "auth": None,
+                            "location": "conda.anaconda.org",
+                            "name": "",  # ← Change None to empty string
+                            "package_filename": None,
+                            "platform": None,
+                            "scheme": "https",
+                            "token": None,
+                        },
+                        "channels": ["defaults"],
+                        "custom_channels": {},
+                        "custom_multichannels": {
+                            "defaults": [
+                                {
+                                    "auth": None,
+                                    "location": "repo.anaconda.com",
+                                    "name": "pkgs/main",
+                                    "package_filename": None,
+                                    "platform": None,
+                                    "scheme": "https",
+                                    "token": None,
+                                }
+                            ]
                         },
                     }
 

--- a/mamba_gator/tests/test_manager.py
+++ b/mamba_gator/tests/test_manager.py
@@ -1,20 +1,85 @@
 from pathlib import Path
 
 import pytest
-from mamba_gator.envmanager import EnvManager
+from packaging.version import Version
+
+from mamba_gator.envmanager import EnvManager, parse_version
 
 from .utils import has_mamba
 
 
 @pytest.mark.skipif(has_mamba, reason="Mamba found")
-def test_EnvManager_manager_conda():
+def test_envmanager_manager_conda():
     manager = EnvManager("", None)
-
     assert Path(manager.manager).stem == "conda"
 
 
 @pytest.mark.skipif(not has_mamba, reason="Mamba NOT found")
-def test_EnvManager_manager_mamba():
+def test_envmanager_manager_mamba():
     manager = EnvManager("", None)
-
     assert Path(manager.manager).stem == "mamba"
+
+
+def test_parse_r_style_version_with_underscore():
+    """Test that R-style versions with underscores are converted to dots."""
+    result = parse_version("1.8_4")
+    assert result == Version("1.8.4")
+
+
+def test_parse_year_based_version_with_letter():
+    """Test that year-based versions like '2023d' are converted correctly."""
+    result = parse_version("2023d")
+    assert result == Version("2023.4")
+
+
+def test_parse_invalid_version_returns_none():
+    """Test that invalid versions return None instead of raising exceptions."""
+    result = parse_version("invalid.version.format!")
+    assert result is None
+
+
+def test_parse_version_with_multiple_underscores():
+    """Test that versions with multiple underscores are handled correctly."""
+    result = parse_version("1.2_3_4")
+    assert result == Version("1.2.3.4")
+
+
+def test_parse_year_version_with_z_suffix():
+    """Test that year versions with 'z' suffix convert to .26."""
+    result = parse_version("2023z")
+    assert result == Version("2023.26")
+
+
+def test_parse_standard_semantic_version_unchanged():
+    """Test that standard semantic versions pass through unchanged."""
+    result = parse_version("1.21.0")
+    assert result == Version("1.21.0")
+
+
+@pytest.mark.asyncio
+async def test_list_available_returns_valid_structure():
+    """Test that list_available returns the expected data structure."""
+    manager = EnvManager("", None)
+    result = await manager.list_available()
+    assert "packages" in result
+    assert "with_description" in result
+
+
+@pytest.mark.asyncio
+async def test_list_available_version_sorting_works():
+    """Test that version sorting works correctly after parsing in list_available."""
+    manager = EnvManager("", None)
+    result = await manager.list_available()
+
+    if result["packages"]:
+        # Find a package with multiple versions to test sorting
+        multi_version_pkg = None
+        for pkg in result["packages"]:
+            if isinstance(pkg.get("version"), list) and len(pkg["version"]) > 1:
+                multi_version_pkg = pkg
+                break
+
+        if multi_version_pkg:
+            # Check that versions are in ascending order
+            versions = [Version(v) for v in multi_version_pkg["version"]]
+            assert versions == sorted(versions)


### PR DESCRIPTION
This is a simple approach to convert versions based on a similar PR I made to nb_conda.

It fixes issues with versions in 1.4_2 and 2024d type formats. A more robust approach with more complexity may be needed in the future to make these version formats better supported - especially if R packages become more officially supported by Conda.