### PR TITLE
Add TODO for removing notebook config

### DIFF
--- a/jupyter-config/jupyter_notebook_config.d/mamba_gator.json
+++ b/jupyter-config/jupyter_notebook_config.d/mamba_gator.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "TODO: Remove entire jupyter_notebook_config.d directory when dropping JupyterLab 3 support (JL4 config already exists in jupyter_server_config.d)",
   "NotebookApp": {
     "nbserver_extensions": {
       "mamba_gator": true


### PR DESCRIPTION
This is a small change as part of our upgrade to JupyterLab4 to add a TODO to remove the Notebook Config file, since JupyterLab4 will use the server config which is already created.