### PR TITLE
CI: Run tests with Conda in offline mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,17 @@ jobs:
           conda install -c conda-forge -n test_gator nb_conda_kernels "jupyterlab${{ matrix.jupyterlab-version }}" "notebook>=6.5.4,<7"
           jupyter --version
           ./install-lab-version.sh "${{ matrix.jupyterlab-version }}"
+
+      - name: Pre-cache test packages
+        run: |
+          conda create -n _test_cache -y --download-only python=3.9 astroid ipykernel nb_conda_kernels jupyter_client jupyter_core traitlets
+          conda clean --tarballs --yes
         shell: bash -l {0}
+
       - name: Test the server extension
+        env:
+          CONDA_OFFLINE: 1
+          CONDA_USE_LOCAL: "true"
         run: python -m pytest -ra mamba_gator
         shell: bash -l {0}
 
@@ -108,8 +117,17 @@ jobs:
           pip install "jupyterlab${{ matrix.jupyterlab-version }}" "notebook>=6.5.4,<7"
           jupyter --version
           ./install-lab-version.sh "${{ matrix.jupyterlab-version }}"
+
+      - name: Pre-cache test packages
+        run: |
+          mamba create -n _test_cache -y --download-only python=3.9 astroid ipykernel nb_conda_kernels jupyter_client jupyter_core traitlets
+          mamba clean --tarballs --yes
         shell: bash -l {0}
+
       - name: Test the server extension
+        env:
+          CONDA_OFFLINE: 1
+          CONDA_USE_LOCAL: "true"
         run: |
           conda activate test_gator
           python -m pytest -ra mamba_gator
@@ -164,10 +182,15 @@ jobs:
           node-version: '18'
           cache: 'yarn'
           
-      - name: Create conda environment
+      - name: Create conda environment and pre-cache test packages
         run: |
           conda info
           conda install -c conda-forge -n test_gator nb_conda_kernels "jupyterlab${{ matrix.jupyterlab-version }}" "notebook>=6.5.4,<7"
+          
+      - name: Pre-cache test packages
+        run: |
+          conda create -n _test_cache -y --download-only python=3.9 astroid ipykernel nb_conda_kernels jupyter_client jupyter_core traitlets
+          conda clean --tarballs --yes
 
       - name: Upgrade conda dependencies on Windows (resolves OSError)
         if: matrix.os == 'windows-latest'
@@ -192,6 +215,8 @@ jobs:
       - name: Test the extension
         env:
           OS_RUNNER: ${{ matrix.os }}
+          CONDA_OFFLINE: 1
+          CONDA_USE_LOCAL: "true"
         run: |
           python -m pytest mamba_gator
           yarn run test
@@ -240,7 +265,7 @@ jobs:
           node-version: '18'
           cache: 'yarn'
  
-      - name: Create mamba environment
+      - name: Create mamba environment and pre-cache test packages
         shell: bash -l {0}
         run: |
           mamba create -y -n test_gator -c conda-forge python=3.9 nb_conda_kernels
@@ -248,6 +273,11 @@ jobs:
           pip install "jupyterlab${{ matrix.jupyterlab-version }}" "notebook>=6.5.4,<7"
           python --version
           jupyter --version
+          
+      - name: Pre-cache test packages
+        run: |
+          mamba create -n _test_cache -y --download-only python=3.9 astroid ipykernel nb_conda_kernels jupyter_client jupyter_core traitlets
+          mamba clean --tarballs --yes
 
       - name: Install Dependencies and Extension
         run: |
@@ -263,6 +293,9 @@ jobs:
         shell: bash -l {0}
 
       - name: Test the extension
+        env:
+          CONDA_OFFLINE: 1
+          CONDA_USE_LOCAL: "true"
         run: |
           conda activate test_gator
           # Run linter

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,11 +55,11 @@ jobs:
           conda install -c conda-forge -n test_gator nb_conda_kernels "jupyterlab${{ matrix.jupyterlab-version }}" "notebook>=6.5.4,<7"
           jupyter --version
           ./install-lab-version.sh "${{ matrix.jupyterlab-version }}"
+        shell: bash -l {0}
 
       - name: Pre-cache test packages
         run: |
-          conda create -n _test_cache -y --download-only python=3.9 astroid ipykernel nb_conda_kernels jupyter_client jupyter_core traitlets
-          conda clean --tarballs --yes
+          conda create -n _test_cache -y -c conda-forge --download-only python=${{ matrix.python-version }} astroid ipykernel nb_conda_kernels
         shell: bash -l {0}
 
       - name: Test the server extension
@@ -117,11 +117,11 @@ jobs:
           pip install "jupyterlab${{ matrix.jupyterlab-version }}" "notebook>=6.5.4,<7"
           jupyter --version
           ./install-lab-version.sh "${{ matrix.jupyterlab-version }}"
+        shell: bash -l {0}
 
       - name: Pre-cache test packages
         run: |
-          mamba create -n _test_cache -y --download-only python=3.9 astroid ipykernel nb_conda_kernels jupyter_client jupyter_core traitlets
-          mamba clean --tarballs --yes
+          mamba create -n _test_cache -y -c conda-forge --download-only python=${{ matrix.python-version }} astroid ipykernel nb_conda_kernels
         shell: bash -l {0}
 
       - name: Test the server extension
@@ -182,15 +182,16 @@ jobs:
           node-version: '18'
           cache: 'yarn'
           
-      - name: Create conda environment and pre-cache test packages
+      - name: Create conda environment
         run: |
           conda info
           conda install -c conda-forge -n test_gator nb_conda_kernels "jupyterlab${{ matrix.jupyterlab-version }}" "notebook>=6.5.4,<7"
-          
+        shell: bash -l {0}
+
       - name: Pre-cache test packages
         run: |
-          conda create -n _test_cache -y --download-only python=3.9 astroid ipykernel nb_conda_kernels jupyter_client jupyter_core traitlets
-          conda clean --tarballs --yes
+          conda create -n _test_cache -y -c conda-forge --download-only python=3.8 astroid ipykernel nb_conda_kernels
+        shell: bash -l {0}
 
       - name: Upgrade conda dependencies on Windows (resolves OSError)
         if: matrix.os == 'windows-latest'
@@ -265,7 +266,7 @@ jobs:
           node-version: '18'
           cache: 'yarn'
  
-      - name: Create mamba environment and pre-cache test packages
+      - name: Create mamba environment
         shell: bash -l {0}
         run: |
           mamba create -y -n test_gator -c conda-forge python=3.9 nb_conda_kernels
@@ -273,11 +274,11 @@ jobs:
           pip install "jupyterlab${{ matrix.jupyterlab-version }}" "notebook>=6.5.4,<7"
           python --version
           jupyter --version
-          
+
       - name: Pre-cache test packages
         run: |
-          mamba create -n _test_cache -y --download-only python=3.9 astroid ipykernel nb_conda_kernels jupyter_client jupyter_core traitlets
-          mamba clean --tarballs --yes
+          mamba create -n _test_cache -y -c conda-forge --download-only python=${{ matrix.python-version }} astroid ipykernel nb_conda_kernels
+        shell: bash -l {0}
 
       - name: Install Dependencies and Extension
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v4
         env:
           # Increase this value to reset cache
-          CACHE_NUMBER: 0
+          CACHE_NUMBER: 1
         with:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('pyproject.toml') }}
@@ -85,7 +85,7 @@ jobs:
         uses: actions/cache@v4
         env:
           # Increase this value to reset cache
-          CACHE_NUMBER: 0
+          CACHE_NUMBER: 1
         with:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-mamba-${{ matrix.python-version }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('pyproject.toml') }}
@@ -154,7 +154,7 @@ jobs:
         uses: actions/cache@v4
         env:
           # Increase this value to reset cache
-          CACHE_NUMBER: 0
+          CACHE_NUMBER: 1
         with:
           path: ~/conda_pkgs_dir
           key: ${{ matrix.os }}-conda-3.8-${{ env.CACHE_NUMBER }}-${{ hashFiles('pyproject.toml') }}
@@ -219,6 +219,7 @@ jobs:
           CONDA_OFFLINE: 1
           CONDA_USE_LOCAL: "true"
         run: |
+          conda activate test_gator
           python -m pytest mamba_gator
           yarn run test
           jupyter serverextension list
@@ -240,7 +241,7 @@ jobs:
         uses: actions/cache@v4
         env:
           # Increase this value to reset cache
-          CACHE_NUMBER: 0
+          CACHE_NUMBER: 1
         with:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-mamba-3.9-${{ env.CACHE_NUMBER }}-${{ hashFiles('pyproject.toml') }}

--- a/mamba_gator/envmanager.py
+++ b/mamba_gator/envmanager.py
@@ -26,15 +26,15 @@ from jupyter_server.utils import url2path, url_path_join
 
 from .log import get_logger
 
-CONDA_EXE = os.environ.get("CONDA_EXE", "conda")  # type: str
+CONDA_EXE: str = os.environ.get("CONDA_EXE", "conda")
 
 PATH_SEP = "\\" + os.path.sep
 CONDA_ENV_PATH = r"^(.*?" + PATH_SEP + r"envs" + PATH_SEP + r".+?)" + PATH_SEP
 
 # try to match lines of json
-JSONISH_RE = r'(^\s*["\{\}\[\],\d])|(["\}\}\[\],\d]\s*$)'  # type: str
+JSONISH_RE: str = r'(^\s*["\{\}\[\],\d])|(["\}\}\[\],\d]\s*$)'
 
-MAX_LOG_OUTPUT = 6000  # type: int
+MAX_LOG_OUTPUT: int = 6000
 
 ROOT_ENV_NAME = "base"
 

--- a/mamba_gator/tests/test_api.py
+++ b/mamba_gator/tests/test_api.py
@@ -54,7 +54,7 @@ class JupyterCondaAPITest(ServerTest):
 
         return self.conda_api.post(
             ["environments"],
-            body={"name": new_name, "packages": packages or ["python!=3.10.0"]},
+            body={"name": new_name, "packages": packages or ["python=3.9"]},
         )
 
     def rm_env(self, name):
@@ -412,7 +412,7 @@ class TestEnvironmentsHandlerWhiteList(JupyterCondaAPITest):
     @mock.patch("nb_conda_kernels.manager.CACHE_TIMEOUT", 0)
     def test_get_whitelist(self):
         n = "banana"
-        self.wait_for_task(self.mk_env, n, packages=["ipykernel",])
+        self.wait_for_task(self.mk_env, n, packages=["python=3.9", "ipykernel"])
         manager = CondaKernelSpecManager()
         manager.whitelist = set(["conda-env-banana-py",])
         env_manager = TestEnvironmentsHandlerWhiteList.notebook.web_app.settings["env_manager"]


### PR DESCRIPTION
This PR attempts to speed up test execution by caching the packages conda needs and then running all the tests offline.