### PR TITLE
Update changelog, replace yarn with jlpm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,7 +207,7 @@ jobs:
         run: |
           conda activate test_gator
           python -m pytest mamba_gator
-          yarn run test
+          jlpm run test
           jupyter serverextension list
           jupyter labextension list
           if [ "${OS_RUNNER}" != "windows-latest" ]; then python -m jupyterlab.browser_check; fi
@@ -280,12 +280,12 @@ jobs:
           conda activate test_gator
           # Run linter
           hatch run lint:check
-          yarn run eslint:check
+          jlpm run eslint:check
 
           # Run test
           coverage run -m pytest mamba_gator
           coverage report
-          yarn run test
+          jlpm run test
 
           jupyter serverextension list
           jupyter serverextension list 2>&1 | grep "mamba_gator.*OK"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,24 +21,23 @@ jobs:
       - name: Install Python build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build twine jupyterlab~=3.0 hatchling
+          pip install build twine jupyterlab=4.0 hatchling
 
       - name: Install frontend dependencies
         run: |
-          npm install -g yarn
-          yarn install
+          jlpm install
 
       - name: Build and publish NPM package
         if: ${{ startsWith(github.event.release.tag_name, 'npm') }}
         run: |
           if [[ ${PRE_RELEASE} == "true" ]]; then export TAG="next"; else export TAG="latest"; fi
           echo Publishing ${VERSION} with distribution tag ${TAG}
-          # yarn lerna version ${VERSION} --yes --no-git-tag-version
+          # jlpm lerna version ${VERSION} --yes --no-git-tag-version
           pushd packages/common
-          yarn run publish --access public --tag ${TAG}
+          jlpm run publish --access public --tag ${TAG}
           popd
           pushd packages/labextension
-          yarn run publish --access public --tag ${TAG}
+          jlpm run publish --access public --tag ${TAG}
           popd
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -50,6 +49,6 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          yarn build
+          jlpm build
           python -m build
           twine upload dist/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing to Gator! This document will help yo
 
 - Conda or Mamba (v1.x) package manager. Mamba v2.x is not currently supported.
 
-> **Note**: Python and Node.js will be automatically installed when you create the development environment. Yarn 3.x is managed via Corepack and will be automatically used based on the `packageManager` field in package.json.
+> **Note**: Python and Node.js will be automatically installed when you create the development environment.
 
 ### Project Structure
 
@@ -28,11 +28,11 @@ This project uses Lerna to manage multiple JavaScript/TypeScript packages in a m
 2. **Create and activate a conda environment**
    ```bash
    # Using conda
-   conda create -c conda-forge -n gator python=3.9 nodejs nb_conda_kernels
+   conda create -c conda-forge -n gator python=3.9 nodejs jupyterlab=4.0 nb_conda_kernels
    conda activate gator
 
    # Or using mamba
-   mamba create -c conda-forge -n gator python=3.9 nodejs nb_conda_kernels
+   mamba create -c conda-forge -n gator python=3.9 nodejs jupyterlab=4.0 nb_conda_kernels
    mamba activate gator
    ```
 
@@ -43,8 +43,7 @@ This project uses Lerna to manage multiple JavaScript/TypeScript packages in a m
 
 4. **Install Node.js dependencies**
    ```bash
-   # Corepack will automatically use yarn@3.x as specified in package.json
-   yarn install
+   jlpm install
    ```
 
 5. **Install the package in development mode**
@@ -57,40 +56,38 @@ This project uses Lerna to manage multiple JavaScript/TypeScript packages in a m
    jupyter labextension develop . --overwrite
    ```
 
-### Package Manager Notes
-
-This project uses **Yarn 3.x** as specified in the `packageManager` field in `package.json`. When you run `corepack enable`, Corepack will automatically manage the yarn version for you. You don't need to install yarn manually - just use the `yarn` commands and Corepack will handle the rest.
-
 ### Common Yarn Commands
 
-When working with the JavaScript/TypeScript packages, you can use these yarn commands. Note that while this project uses Lerna for monorepo management, the commands are wrapped in yarn scripts for convenience:
+When working with the JavaScript/TypeScript packages, you can use these yarn commands
+which are wrapped in to a command called jlpm. Note that while this project uses Lerna for monorepo management,
+the commands are also executed using jlpm:
 
 ```bash
 # Install dependencies for all packages (uses yarn workspaces)
-yarn install
+jlpm install
 
 # Build all packages (uses lerna run build internally)
-yarn run build
+jlpm run build
 
 # Build packages in development mode
-yarn run build:dev
+jlpm run build:dev
 
 # Build packages for production
-yarn run build:prod
+jlpm run build:prod
 
 # Run tests for all packages (uses lerna run test internally)
-yarn run test
+jlpm run test
 
 # Run linters
-yarn run eslint:check
-yarn run prettier:check
+jlpm run eslint:check
+jlpm run prettier:check
 
 # Fix linting issues
-yarn run eslint
-yarn run prettier
+jlpm run eslint
+jlpm run prettier
 
 # Clean build artifacts (uses lerna run clean internally)
-yarn run clean
+jlpm run clean
 ```
 
 ### Running Tests
@@ -102,11 +99,11 @@ To run the tests, you can use the following commands:
 python -m pytest mamba_gator
 
 # Run JavaScript tests
-yarn run test
+jlpm run test
 
 # Run linters
 flake8 setup.py mamba_gator
-yarn run eslint:check
+jlpm run eslint:check
 ```
 
 ### Verifying Installation
@@ -133,7 +130,7 @@ python -m jupyterlab.browser_check
 
 - Python code should follow PEP 8 guidelines
 - JavaScript code should pass ESLint checks
-- Run `flake8` and `yarn run eslint:check` before submitting changes
+- Run `flake8` and `jlpm run eslint:check` before submitting changes
 
 ## Need Help?
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Provides Conda/Mamba environment and package management as a [standalone applica
 
 _Requirements_
 
-- conda >= 4.5 or mamba >=0.5
-- JupyterLab 1.x, 2.x or 3.x (for the JupyterLab extension only)
+- conda >= 4.5 or mamba 1.x 
+- JupyterLab 4.0.x (for the JupyterLab extension only)
 
 > Starting from 3.4, this extension will use [mamba](https://github.com/mamba-org/mamba) instead of `conda` if it finds it.
 
@@ -29,12 +29,6 @@ To install in the JupyterLab:
 
 ```shell
 mamba install -c conda-forge jupyterlab mamba_gator
-```
-
-If you use JupyterLab 1.x or 2.x, you can install the extension with the following command:
-
-```shell
-jupyter labextension install @mamba-org/gator-lab
 ```
 
 > Optionally, you could install [`jupyterlab-tour`](https://github.com/fcollonval/jupyterlab-tour) to
@@ -90,26 +84,36 @@ Open JupyterLab: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybind
 
 ## Development
 
-```shell
-mamba create -c conda-forge -y -n gator python=3.9 nodejs "yarn<2.0.0" nb_conda_kernels
-conda activate gator
-pip install -e .
-jupyter server extension enable mamba_gator --sys-prefix
+To setup a development environment follow our [Contributing Guide](CONTRIBUTING.md).
 
-yarn install
-yarn run build:dev
-jupyter labextension link packages/common/ packages/labextension/
+If you would like to try a pre-release version:
+
+```shell
+conda create -c conda-forge -y -n gator python=3.13 nodejs jupyterlab=4.0 
+conda activate gator
+pip install git+https://github.com/mamba-org/gator.git
+jupyter lab
 ```
 
 ## Acknowledgements
 
-This work started as a fork by [@fcollonval](https://github.com/fcollonval/) of the Anaconda [nb_conda package](https://github.com/Anaconda-Platform/nb_conda). The decision to fork it came due
-to apparently dead status of the previous package and a need to integrate it within JupyterLab.
+This work started as a fork by [@fcollonval](https://github.com/fcollonval/) of the Anaconda [nb_conda package](https://github.com/Anaconda-Platform/nb_conda) to add
+JupyterLab support.
 
 Then with the [mamba initiative](https://medium.com/@QuantStack/open-software-packaging-for-science-61cecee7fc23) pushed by QuantStack it made
 sense to move the project in the `mamba-org` organization.
 
 ## Changelog
+
+### 6.0.0
+- Maintenance:
+  - Migrate from JupyterLab 3 to JupyterLab 4.0 support
+  - Migrate from Setuptools to Hatch
+  - Remove support for Python 3.7
+  - Add support for Python up to 3.13
+  - Update out of date GitHub Actions
+- Docs:
+  - Add Contributing Guide
 
 ### 5.1.2
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "author": "Jupyter Development Team",
   "license": "BSD-3-Clause",
-  "packageManager": "yarn@3.8.7",
   "engines": {
     "node": ">=18.0.0"
   },
@@ -24,13 +23,13 @@
   "scripts": {
     "build": "lerna run build",
     "build:dev": "lerna run build:dev",
-    "build:prod": "yarn install && lerna run build:prod",
+    "build:prod": "jlpm install && lerna run build:prod",
     "clean": "lerna run clean",
     "eslint": "eslint . --fix --ext .ts,.tsx",
     "eslint:check": "eslint . --ext .ts,.tsx",
     "prettier": "npx prettier --write \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
     "prettier:check": "npx prettier --list-different \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
-    "publish": "yarn run clean && yarn run build && lerna publish",
+    "publish": "jlpm run clean && jlpm run build && lerna publish",
     "test": "lerna run test"
   },
   "devDependencies": {

--- a/packages/navigator/package.json
+++ b/packages/navigator/package.json
@@ -18,9 +18,9 @@
   "scripts": {
     "build": "tsc && webpack --mode=production",
     "build:dev": "tsc && webpack",
-    "build:prod": "yarn run build",
+    "build:prod": "jlpm run build",
     "clean": "rimraf lib tsconfig.tsbuildinfo ../../mamba_gator/navigator/static/*.* ../../mamba_gator/nbextension/static/*.*",
-    "prepublishOnly": "yarn run build",
+    "prepublishOnly": "jlpm run build",
     "watch:ts": "tsc -w --listEmittedFiles",
     "watch:webpack": "webpack --watch",
     "watch": "npm-run-all --parallel watch:ts watch:webpack"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ build-function = "hatch_jupyter_builder.npm_builder"
 path = "."
 build_cmd = "build:prod"
 npm = [
-    "yarn",
+    "jlpm",
 ]
 
 [tool.tbump]


### PR DESCRIPTION
I noticed when we were doing testing that it required another step to enable corepack after an environment was created. This PR updates it so that the package is built directly using jlpm instead of yarn, which is already included with JupyterLab 4.

I also updated the changelog and refreshed the contributing instructions.