### PR TITLE
Skip frontend build if static files are present, Add CI job to verify

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -348,5 +348,5 @@ jobs:
           # Use unshare to create a network namespace that blocks network access
           cd sdist/test
           python -m venv .venv
-          .venv/bin/python -m pip install build jupyter-server hatch-jupyter-builder
+          .venv/bin/python -m pip install build jupyter-server hatch-jupyter-builder jupyterlab
           sudo unshare --net bash -c ".venv/bin/python -m build --no-isolation --wheel"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ requires = [
     "hatchling>=1.9.0",
     "jupyterlab>=3.6.7,<5.0.0",
     "jupyter-server",
-    "setuptools",
 ]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
This PR references: https://github.com/jupyter/nbclassic/pull/337 by @danyeaw to add a CI job verifying that offline builds succeed. This aims to address #237.