### PR TITLE
Update the delete environment icon to a trash bin

### DIFF
--- a/packages/common/src/components/CondaEnvToolBar.tsx
+++ b/packages/common/src/components/CondaEnvToolBar.tsx
@@ -3,7 +3,7 @@ import { ToolbarButtonComponent } from '@jupyterlab/apputils';
 import {
   addIcon,
   Button,
-  closeIcon,
+  deleteIcon,
   downloadIcon,
   fileUploadIcon
 } from '@jupyterlab/ui-components';
@@ -101,7 +101,7 @@ export const CondaEnvToolBar = (props: ICondaEnvToolBarProps): JSX.Element => {
           onClick={props.onExport}
         />
         <ToolbarButtonComponent
-          icon={closeIcon}
+          icon={deleteIcon}
           tooltip="Remove"
           onClick={props.onRemove}
           enabled={!props.isBase}


### PR DESCRIPTION
This PR updates the icon for environment deletion from an 'x' to a trash bin 

<img width="254" height="157" alt="Screenshot 2025-07-10 at 7 21 49 PM" src="https://github.com/user-attachments/assets/f3d879f5-45cf-42ce-8218-397586799218" />
