### PR TITLE
Display package versions from newest to oldest

### DIFF
--- a/mamba_gator/envmanager.py
+++ b/mamba_gator/envmanager.py
@@ -805,7 +805,7 @@ class EnvManager:
                             max_build_numbers[version_idx] = build_number
                             max_build_strings[version_idx] = entry.get("build_string", "")
 
-                sorted_versions_idx = sorted(range(len(versions)), key=versions.__getitem__)
+                sorted_versions_idx = sorted(range(len(versions)), key=versions.__getitem__, reverse=True)
 
                 pkg_entry["version"] = [str(versions[i]) for i in sorted_versions_idx]
                 pkg_entry["build_number"] = [max_build_numbers[i] for i in sorted_versions_idx]


### PR DESCRIPTION
This PR modifies the package versions to be listed from newest to oldest

Before
<img width="390" height="129" alt="Before" src="https://github.com/user-attachments/assets/14b21e5f-b1e7-447b-8e68-709359fc6262" />

After
<img width="501" height="121" alt="After" src="https://github.com/user-attachments/assets/f96682b9-4698-4787-90e3-76c41f3c9f1c" />
