### PR TITLE
Add launcher tile for Gator

### DIFF
--- a/packages/common/style/conda.svg
+++ b/packages/common/style/conda.svg
@@ -1,59 +1,206 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<!--
+Copyright (c) 2022, conda-incubator
+All rights reserved.
+ -->
+
 <svg
-   xmlns="http://www.w3.org/2000/svg"
+   width=""
+   height=""
+   viewBox="0 0 23.564676 27.148796"
    version="1.1"
-   viewBox="0 0 32 32"
->
+   id="svg5563"
+   inkscape:version="1.2.2 (b0a84865, 2022-12-01)"
+   sodipodi:docname="conda_c.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview5565"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="2.3743555"
+     inkscape:cx="64.017373"
+     inkscape:cy="81.916967"
+     inkscape:window-width="1306"
+     inkscape:window-height="1027"
+     inkscape:window-x="1840"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs5560">
+    <mask
+       id="mask"
+       x="9.83"
+       y="63.06"
+       width="73.56"
+       height="34.87"
+       maskUnits="userSpaceOnUse" />
+    <mask
+       id="mask-1"
+       x=".13"
+       y=".13"
+       width="90.54"
+       height="103.93"
+       maskUnits="userSpaceOnUse" />
+  </defs>
   <g
-     transform="translate(0,-288.53332)"
-     id="layer1">
-    <path
-       id="path4524"
-       transform="translate(0,288.53332)"
-       d="M 15.464844 0.2890625 C 10.532572 0.46372875 5.6744883 2.7638825 2.9316406 7.1171875 C -3.1950453 15.383908 1.4004053 28.557982 11.335938 31.226562 C 21.037771 34.626923 32.275324 26.360339 31.884766 16.074219 C 31.893598 12.524759 30.661113 8.9899438 28.447266 6.2148438 C 25.403349 2.0664537 20.397116 0.11439625 15.464844 0.2890625 z M 15.642578 5.3164062 C 19.004239 5.1973638 22.417562 6.5261406 24.492188 9.3535156 C 26.001067 11.244966 26.840004 13.655009 26.833984 16.074219 C 27.100174 23.084889 19.440549 28.719904 12.828125 26.402344 C 6.0564208 24.583524 2.9258322 15.60306 7.1015625 9.96875 C 8.9709896 7.001705 12.280918 5.4354487 15.642578 5.3164062 z "
-       style="fill:#3baf29;fill-opacity:1;stroke-width:1.98490679;stroke-miterlimit:4;stroke-dasharray:none" />
-    <path
-       style="fill:none;stroke:#ffffff;stroke-width:0.9924534px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 0.26938262,297.92945 C 3.7810355,296.31532 7.8503371,295.92724 11.610497,296.8016"
-       id="path4528" />
-    <path
-       style="fill:none;stroke:#ffffff;stroke-width:0.9924534px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 5.0644119,292.25647 c -0.4739812,3.8357 0.3894297,7.83124 2.362212,11.1496"
-       id="path4528-8" />
-    <path
-       style="fill:none;stroke:#ffffff;stroke-width:0.9924534px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M -1.09548,304.50624 C 1.767,301.90946 5.5304889,300.31386 9.379392,300.01516"
-       id="path4528-2" />
-    <path
-       style="fill:none;stroke:#ffffff;stroke-width:0.9924534px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 1.7683793,297.65256 c 0.7032257,3.80033 2.7298967,7.35032 5.6104711,9.92047"
-       id="path4528-8-4" />
-    <path
-       style="fill:none;stroke:#ffffff;stroke-width:0.9924534px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M -0.86357437,310.97102 C 1.3509942,307.80356 4.6663492,305.4123 8.3528986,304.26663"
-       id="path4528-2-6" />
-    <path
-       style="fill:none;stroke:#ffffff;stroke-width:0.9924534px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 0.21260444,303.86163 c 2.12159416,3.23048 5.36607136,5.7171 9.01778526,6.96941"
-       id="path4528-8-4-8" />
-    <path
-       style="fill:none;stroke:#ffffff;stroke-width:0.9924534px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 2.902101,317.30745 c 0.8829156,-3.76267 3.0758903,-7.2124 6.0752729,-9.64282"
-       id="path4528-2-6-8" />
-    <path
-       style="fill:none;stroke:#ffffff;stroke-width:0.9924534px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 0.37540797,309.70348 c 3.01572983,2.41712 6.86964513,3.77993 10.72960903,3.84298"
-       id="path4528-8-4-8-0" />
-    <path
-       style="fill:none;stroke:#ffffff;stroke-width:0.9924534px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 4.4102643,292.88266 c 3.8309474,-0.51081 7.8346027,0.31434 11.1717647,2.25492"
-       id="path4528-5" />
-    <path
-       style="fill:none;stroke:#ffffff;stroke-width:0.9924534px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 11.788587,289.43332 c -2.2962999,2.93729 -3.4473982,6.9266 -2.409195,10.58184"
-       id="path4528-8-1" />
-    <path
-       style="fill:none;stroke:#ffffff;stroke-width:0.9924534px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 10.660742,288.86939 c 1.841925,0.2667 3.492402,1.24721 4.985484,2.30863 -0.91722,2.21223 -2.351376,4.23807 -4.177641,5.78866 0.533951,-0.59025 1.195816,-1.06367 1.807423,-1.57264"
-       id="path4528-5-3" />
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-0.05942344,-0.14795301)">
+    <g
+       id="g702"
+       transform="matrix(0.26458333,0,0,0.26458333,-0.12943257,-0.10469531)">
+      <path
+         id="path21"
+         class="cls-2"
+         d="m 25.16,55.61 c -1.96,-0.47 -5.91,-1.69 -10.17,-4.38 4.63,-2.64 8.73,-3.09 10.23,-3.2 0.24,-1.74 0.65,-3.35 1.11,-4.97 -1.49,-1.17 -4.37,-3.5 -7,-6.99 4.27,-0.33 7.95,0.27 9.79,0.63 0.93,-1.62 2,-3.26 3.39,-4.76 -0.8,-1.39 -2.19,-4.05 -3.09,-7.88 3.45,1.52 5.87,3.21 7.13,4.25 1.74,-1.27 3.65,-2.19 5.5,-3.11 0,-1.62 0.07,-4.45 0.78,-7.92 2.41,2.56 3.89,4.9 4.46,6.18 2.31,-0.45 4.74,-0.57 7.28,-0.44 0.47,-1.27 1.4,-3.47 3.03,-6.13 1.14,3.02 1.59,5.46 1.81,6.73 2.53,0.59 5.03,1.37 7.33,2.54 3.71,-3.11 7.1,-4.44 11.14,-5.47 C 77.9,15.59 77,10.43 74.37,5.43 71.72,4.14 69.09,3.37 66.21,2.66 63.2,4.27 60.77,6.11 58.69,8.07 57.2,5.74 55.25,3.3 52.84,1.09 51.69,1.09 49.5,0.96 45.23,1.63 43.14,4.29 41.63,6.95 40.46,9.61 37.93,7.97 34.82,6.57 31.25,5.62 c -2.08,0.92 -4.05,1.95 -6.01,3.1 -0.71,3.36 -0.95,6.49 -0.85,9.39 -3,-0.59 -6.45,-0.84 -10.15,-0.4 -1.28,1.38 -2.56,2.83 -3.73,4.45 0.21,4.17 1.24,7.83 2.73,10.96 -3.46,0.79 -7.05,2.28 -10.4,4.59 -0.47,1.5 -0.69,3.07 -1.04,4.58 2.06,3.6 4.68,6.72 7.33,8.94 -2.66,2.19 -5.19,5.02 -7.63,9.06 0.22,1.74 0.45,3.39 0.91,5.02 h 0.06 c 2.8,-5.78 6.06,-9.6 9.3,-12.13 6.55,4.55 13.21,5.86 14.14,5.98 -0.08,-0.31 -0.56,-1.91 -0.66,-3.3 L 25.18,55.6 Z M 69.3,6.63 c 2.29,3.49 3.08,7.78 3.3,10.22 -2.08,0.8 -5.32,2.29 -8.44,4.83 -0.45,-2.2 -1.24,-5.45 -2.95,-9.17 2.09,-2.08 4.75,-4.15 8.1,-5.87 v 0 z M 49.13,4.21 c 2.76,2.33 4.82,5.12 6.31,7.68 -2.44,3.12 -3.95,6.12 -4.77,8.21 -1.14,-2.09 -3.21,-4.88 -6.31,-7.68 1.05,-2.66 2.56,-5.55 4.77,-8.21 z M 29.38,9.8 c 4.03,0.83 7.14,2.35 9.78,4.22 -1.17,4.05 -1.42,7.64 -1.43,9.96 -2.07,-1.52 -5.06,-3.39 -8.97,-4.68 -0.33,-2.78 -0.2,-6.03 0.62,-9.5 z m -4.33,12.73 c 0.79,4.52 2.33,7.96 3.47,10.17 -2.65,-0.48 -6.75,-0.8 -11.25,-0.24 -1.49,-2.91 -2.62,-6.5 -2.83,-10.56 3.92,-0.44 7.5,-0.08 10.61,0.63 z M 4.78,40.98 c 3.36,-2.42 7.05,-3.68 10.4,-4.36 2.4,3.84 5.39,6.63 7.46,8.38 -2.65,0.45 -6.58,1.48 -10.74,4.12 C 9.37,47.14 6.85,44.46 4.79,40.97 v 0 z"
+         style="fill:#ffffff;fill-rule:evenodd;stroke:#2db24a;stroke-width:0.25px" />
+      <g
+         id="g23">
+        <path
+           id="path25"
+           class="cls-1"
+           d="m 47.3,23.46 c -0.69,-1.27 -2.08,-3.82 -4.51,-6.25 -0.81,3.47 -0.81,6.48 -0.69,7.99 -0.12,0 2.2,-1.16 5.2,-1.74 z"
+           style="fill:#43b02a;fill-rule:evenodd;stroke:#43b02a;stroke-width:0.25px" />
+        <path
+           id="path35"
+           class="cls-1"
+           d="m 36.54,28.32 c -1.27,-1.04 -3.7,-2.89 -7.28,-4.4 0.92,3.82 2.43,6.6 3.24,7.99 0,0.23 1.62,-1.74 4.05,-3.59 v 0 z"
+           style="fill:#43b02a;fill-rule:evenodd;stroke:#43b02a;stroke-width:0.25px" />
+        <path
+           id="path37"
+           class="cls-1"
+           d="M 50.67,20.08 C 51.48,18 52.98,14.99 55.41,11.86 53.91,9.2 51.83,6.54 49.05,4.22 c -2.2,2.78 -3.7,5.56 -4.74,8.33 3.12,2.66 5.09,5.44 6.36,7.52 v 0 z"
+           style="fill:#43b02a;fill-rule:evenodd;stroke:#43b02a;stroke-width:0.25px" />
+        <path
+           id="path39"
+           class="cls-1"
+           d="m 29.15,36.66 c -1.22,-0.22 -2.56,-0.41 -4,-0.52 -2.12,-0.17 -4.06,-0.17 -5.77,-0.06 1.01,1.29 2.24,2.71 3.73,4.14 1.12,1.07 2.21,1.99 3.24,2.78 0.35,-1.03 0.77,-2.12 1.28,-3.28 0.49,-1.11 1.01,-2.13 1.51,-3.06 z"
+           style="fill:#43b02a;fill-rule:evenodd;stroke:#43b02a;stroke-width:0.25px" />
+        <path
+           id="path43"
+           class="cls-1"
+           d="m 11.92,49.15 c 4.16,-2.66 8.09,-3.82 10.75,-4.17 -2.08,-1.74 -5.09,-4.51 -7.52,-8.33 -3.47,0.69 -7.01,2.02 -10.36,4.33 1.97,3.47 4.47,6.2 7.12,8.17 v 0 z"
+           style="fill:#43b02a;fill-rule:evenodd;stroke:#43b02a;stroke-width:0.25px" />
+        <path
+           id="path45"
+           class="cls-1"
+           d="m 25.21,48.11 c -1.62,0.12 -5.56,0.34 -10.19,3.12 4.28,2.66 8.22,4.06 10.19,4.52 v 0 c -0.35,-2.55 -0.35,-5.21 0,-7.64 z"
+           style="fill:#43b02a;fill-rule:evenodd;stroke:#43b02a;stroke-width:0.25px" />
+        <path
+           id="path47"
+           class="cls-1"
+           d="m 39.21,14.02 c -2.54,-1.74 -5.78,-3.24 -9.83,-4.17 -0.81,3.47 -0.92,6.71 -0.69,9.49 3.93,1.27 6.94,3.12 9.02,4.63 0,-2.31 0.35,-5.9 1.5,-9.95 z"
+           style="fill:#43b02a;fill-rule:evenodd;stroke:#43b02a;stroke-width:0.25px" />
+        <path
+           id="path49"
+           class="cls-1"
+           d="m 74.58,5.55 c 0,0 3.24,9.95 3.35,15.04 -3.93,0.93 -7.4,2.31 -11.21,5.56 2.08,1.04 3.93,2.31 5.67,3.82 1.85,1.62 3.58,2.31 6.01,1.16 1.39,-0.93 9.13,-8.91 9.94,-9.95 1.85,-1.97 1.39,-5.21 -0.58,-6.71 C 82.9,9.96 74.58,5.56 74.58,5.56 Z"
+           style="fill:#43b02a;fill-rule:evenodd;stroke:#43b02a;stroke-width:0.25px" />
+        <path
+           id="path51"
+           class="cls-1"
+           d="M 2.82,37.77 C 6.29,35.46 9.76,33.95 13.23,33.14 11.73,30.02 10.69,26.43 10.46,22.26 7.11,27 4.45,32.33 2.83,37.77 v 0 z"
+           style="fill:#43b02a;fill-rule:evenodd;stroke:#43b02a;stroke-width:0.25px" />
+        <path
+           id="path55"
+           class="cls-1"
+           d="M 28.59,32.72 C 27.43,30.52 25.93,26.93 25.12,22.54 22,21.85 18.53,21.5 14.48,22.08 c 0.23,4.05 1.39,7.52 2.89,10.53 4.62,-0.69 8.56,-0.35 11.22,0.12 v 0 z"
+           style="fill:#43b02a;fill-rule:evenodd;stroke:#43b02a;stroke-width:0.25px" />
+        <path
+           id="path59"
+           class="cls-3"
+           d="m 14.22,17.73 c 1.52,-0.19 3.32,-0.3 5.35,-0.22 1.82,0.08 3.44,0.3 4.83,0.56 0.29,-3.12 0.58,-6.24 0.88,-9.37 -1.76,1.02 -3.75,2.34 -5.82,4.02 -2.12,1.73 -3.85,3.45 -5.23,5 z"
+           style="fill:#43b02a;fill-rule:evenodd;stroke:#43b02a;stroke-width:0.25px;stroke-linecap:round" />
+        <path
+           class="cls-5"
+           d="m 31.2,5.66 c 2.19,0.64 4.61,1.55 7.12,2.84 0.75,0.38 1.46,0.78 2.13,1.17 0.49,-1.21 1.12,-2.56 1.93,-3.98 0.89,-1.57 1.83,-2.91 2.7,-4.03 C 42.93,2.02 40.55,2.54 38,3.28 35.47,4.01 33.2,4.83 31.2,5.66 Z"
+           id="path679"
+           style="fill:#43b02a;stroke:#43b02a;stroke-width:0.25px" />
+        <path
+           id="path71"
+           class="cls-1"
+           d="M 9.14,51.23 C 6.48,49.03 3.82,46.14 1.74,42.55 0.58,48.45 0.58,54.7 1.51,60.49 3.71,56.44 6.37,53.55 9.14,51.23 Z"
+           style="fill:#43b02a;fill-rule:evenodd;stroke:#43b02a;stroke-width:0.25px" />
+        <path
+           id="path75"
+           class="cls-1"
+           d="M 86.84,81.09 C 79.56,74.15 78.05,69.63 71.93,74.38 55.17,87.57 31,79.7 25.91,59.22 24.99,59.1 18.51,57.83 11.92,53.32 8.68,55.87 5.33,59.8 2.55,65.47 H 2.43 c 10.52,39.81 61.74,49.07 85.44,24.19 3.93,-4.17 0.35,-7.06 -1.04,-8.56 v 0 z"
+           style="fill:#43b02a;fill-rule:evenodd;stroke:#43b02a;stroke-width:0.25px" />
+        <path
+           id="path79"
+           class="cls-1"
+           d="m 69.26,6.58 c -3.35,1.62 -6.01,3.7 -8.09,5.9 1.73,3.7 2.54,7.06 3.01,9.14 3.24,-2.55 6.47,-4.05 8.44,-4.86 -0.23,-2.31 -1.04,-6.6 -3.35,-10.18 v 0 z"
+           style="fill:#43b02a;fill-rule:evenodd;stroke:#43b02a;stroke-width:0.25px" />
+        <path
+           id="path83"
+           class="cls-1"
+           d="m 57.59,16.75 c -0.85,1.29 -1.7,2.84 -2.43,4.65 -0.22,0.56 -0.42,1.1 -0.59,1.62 0.8,0.04 1.66,0.12 2.56,0.23 0.82,0.1 1.6,0.23 2.32,0.38 -0.13,-0.88 -0.3,-1.84 -0.55,-2.86 -0.38,-1.52 -0.84,-2.87 -1.32,-4.02 z"
+           style="fill:#43b02a;fill-rule:evenodd;stroke:#43b02a;stroke-width:0.25px" />
+        <path
+           id="path87"
+           class="cls-1"
+           d="M 58.67,8.08 C 59.71,7.1 60.97,6.03 62.45,4.98 63.77,4.04 65.03,3.28 66.19,2.67 64.27,2.21 62.09,1.79 59.68,1.5 57.16,1.2 54.85,1.1 52.8,1.12 c 2.42,2.21 4.38,4.64 5.87,6.96 z"
+           style="fill:#43b02a;fill-rule:evenodd;stroke:#43b02a;stroke-width:0.25px" />
+      </g>
+      <g
+         id="g99-Clipped">
+        <g
+           class="cls-8"
+           mask="url(#mask)"
+           id="g697">
+          <g
+             id="g99">
+            <g
+               id="g694">
+              <g
+                 id="rect107-Clipped">
+                <g
+                   class="cls-9"
+                   mask="url(#mask-1)"
+                   id="g688">
+                  <rect
+                     id="rect107"
+                     class="cls-7"
+                     x="2.3199999"
+                     y="55.669998"
+                     width="88.339996"
+                     height="49.66"
+                     style="fill:#ffffff;stroke:#2db24a;stroke-width:0.25px" />
+                </g>
+              </g>
+              <g
+                 id="use109">
+                <path
+                   class="cls-6"
+                   d="M 0.12,0.12 V 104.06 H 90.66 V 0.12 Z"
+                   id="path691"
+                   style="fill:none;stroke:#2db24a;stroke-width:0.25px" />
+              </g>
+            </g>
+          </g>
+        </g>
+      </g>
+      <g
+         id="use111">
+        <path
+           id="SVGID"
+           class="cls-6"
+           d="m 21.03,65.02 c 3.7,9.82 16.63,22.86 32.56,22.86 8.78,0 16.74,-3.12 22.98,-8.43 0.46,-0.23 4.73,4.62 6.47,6.47 0.35,0.46 0.35,0.58 0.35,0.58 -21.02,18.36 -56.7,15.71 -73.56,-16.05 1.39,-4.62 3.35,-7.39 3.35,-7.39 4.5,1.85 7.85,1.96 7.85,1.96 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#2db24a;stroke-width:0.25px" />
+      </g>
+    </g>
   </g>
 </svg>

--- a/packages/labextension/package.json
+++ b/packages/labextension/package.json
@@ -50,6 +50,7 @@
     "@jupyterlab/application": "^4.0.0",
     "@jupyterlab/apputils": "^4.0.0",
     "@jupyterlab/coreutils": "^6.0.0",
+    "@jupyterlab/launcher": "^4.0.0",
     "@jupyterlab/mainmenu": "^4.0.0",
     "@jupyterlab/services": "^7.0.0",
     "@jupyterlab/settingregistry": "^4.0.0",

--- a/packages/labextension/src/index.ts
+++ b/packages/labextension/src/index.ts
@@ -11,6 +11,7 @@ import {
 } from '@jupyterlab/apputils';
 import { IMainMenu } from '@jupyterlab/mainmenu';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { ILauncher } from '@jupyterlab/launcher';
 import {
   CondaEnvironments,
   CondaEnvWidget,
@@ -34,7 +35,8 @@ async function activateCondaEnv(
   settingsRegistry: ISettingRegistry | null,
   palette: ICommandPalette | null,
   menu: IMainMenu | null,
-  restorer: ILayoutRestorer | null
+  restorer: ILayoutRestorer | null,
+  launcher: ILauncher | null
 ): Promise<IEnvironmentManager> {
   let tour: any;
   const { commands, shell } = app;
@@ -110,8 +112,17 @@ async function activateCondaEnv(
         shell.add(condaWidget, 'main');
       }
       shell.activateById(condaWidget.id);
-    }
+    },
+    icon: condaIcon
   });
+
+  if (launcher) {
+    launcher.add({
+      command,
+      category: 'Gator',
+      rank: 1
+    });
+  }
 
   // Add command to command palette
   if (palette) {
@@ -172,7 +183,13 @@ const condaManager: JupyterFrontEndPlugin<IEnvironmentManager> = {
   id: CONDAENVID,
   autoStart: true,
   activate: activateCondaEnv,
-  optional: [ISettingRegistry, ICommandPalette, IMainMenu, ILayoutRestorer],
+  optional: [
+    ISettingRegistry,
+    ICommandPalette,
+    IMainMenu,
+    ILayoutRestorer,
+    ILauncher
+  ],
   provides: IEnvironmentManager
 };
 
@@ -184,7 +201,7 @@ const companions: JupyterFrontEndPlugin<ICompanionValidator> = {
   autoStart: true,
   activate: activateCompanions,
   requires: [IEnvironmentManager, ISettingRegistry],
-  optional: [ICommandPalette],
+  optional: [ICommandPalette, ILauncher],
   provides: ICompanionValidator
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2346,6 +2346,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/coreutils@npm:^6.4.5":
+  version: 6.4.5
+  resolution: "@jupyterlab/coreutils@npm:6.4.5"
+  dependencies:
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/signaling": ^2.1.4
+    minimist: ~1.2.0
+    path-browserify: ^1.0.0
+    url-parse: ~1.5.4
+  checksum: ef4777d66ffc1a005b33b15f87b493d7476e1d0951c9a06a3a74dea69040f61300f6db270f6902b589b14ed2332fa6070b8f39c289db787f76f1651963db6e11
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/docmanager@npm:^4.4.4":
   version: 4.4.4
   resolution: "@jupyterlab/docmanager@npm:4.4.4"
@@ -2444,6 +2458,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/launcher@npm:^4.0.0":
+  version: 4.4.5
+  resolution: "@jupyterlab/launcher@npm:4.4.5"
+  dependencies:
+    "@jupyterlab/apputils": ^4.5.5
+    "@jupyterlab/translation": ^4.4.5
+    "@jupyterlab/ui-components": ^4.4.5
+    "@lumino/algorithm": ^2.0.3
+    "@lumino/commands": ^2.3.2
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/properties": ^2.0.3
+    "@lumino/widgets": ^2.7.1
+    react: ^18.2.0
+  checksum: 10a4cda61174be7e08dd1bdb817f9e71e76a8c7a49a28c576b86c5f97ef48fcc1f3d22b0f68d3b2c34502db7517fe548bc6c9790c1605309ab29fccdfb57c496
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/lsp@npm:^4.4.4":
   version: 4.4.4
   resolution: "@jupyterlab/lsp@npm:4.4.4"
@@ -2497,6 +2529,15 @@ __metadata:
   dependencies:
     "@lumino/coreutils": ^2.2.1
   checksum: 976230c78fc3691a259fa41f28770431c20772687b61321814a9870ccac13d7e552e0edeeac54264dbd19a60070e0a9535974ba8581e2bf6e5cf0a9d08dc308b
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/nbformat@npm:^4.4.5":
+  version: 4.4.5
+  resolution: "@jupyterlab/nbformat@npm:4.4.5"
+  dependencies:
+    "@lumino/coreutils": ^2.2.1
+  checksum: 8f42dd689693a70b196e34ad68c915b9217a77355428b5344f545f4d89373b302deb5a6b31426ee7cc78a77ab83db9e7714ef7c23f9cb35ea7ffbc120f98aef6
   languageName: node
   linkType: hard
 
@@ -2564,6 +2605,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/observables@npm:^5.4.5":
+  version: 5.4.5
+  resolution: "@jupyterlab/observables@npm:5.4.5"
+  dependencies:
+    "@lumino/algorithm": ^2.0.3
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/messaging": ^2.0.3
+    "@lumino/signaling": ^2.1.4
+  checksum: 299e257c73def84d980b15c6651908280c44d7130b8666799b168558bd83d9f3838d54e090a5b6d96db43a0150d21279aebb814018f5ce8518e5a8d04dccc3c3
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/outputarea@npm:^4.4.4":
   version: 4.4.4
   resolution: "@jupyterlab/outputarea@npm:4.4.4"
@@ -2603,6 +2657,16 @@ __metadata:
     "@lumino/coreutils": ^1.11.0 || ^2.2.1
     "@lumino/widgets": ^1.37.2 || ^2.7.1
   checksum: f90e1b83b5ebb576f15ec49e4d4adf7f19b2acc4d2fdfc6bad955e9337e5fa229af45bada70d5ecae95bf2bfef9989003bad99fa0c0a03108055395ef687fae5
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/rendermime-interfaces@npm:^3.12.5":
+  version: 3.12.5
+  resolution: "@jupyterlab/rendermime-interfaces@npm:3.12.5"
+  dependencies:
+    "@lumino/coreutils": ^1.11.0 || ^2.2.1
+    "@lumino/widgets": ^1.37.2 || ^2.7.1
+  checksum: c0734aa5b0d2d62533786a18fc765cdaa6887a2467daebfbd8a47dcd6e61459586d13d93a08bbafbf612f6661630d73529dfc59f40ac5067aa0e32c6075d8565
   languageName: node
   linkType: hard
 
@@ -2664,6 +2728,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/services@npm:^7.4.5":
+  version: 7.4.5
+  resolution: "@jupyterlab/services@npm:7.4.5"
+  dependencies:
+    "@jupyter/ydoc": ^3.0.4
+    "@jupyterlab/coreutils": ^6.4.5
+    "@jupyterlab/nbformat": ^4.4.5
+    "@jupyterlab/settingregistry": ^4.4.5
+    "@jupyterlab/statedb": ^4.4.5
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/polling": ^2.1.4
+    "@lumino/properties": ^2.0.3
+    "@lumino/signaling": ^2.1.4
+    ws: ^8.11.0
+  checksum: b4ede0075dc2d36f0115046b54a044fb34e20e26065d8b158c80503df50ed56c848055419c55cf72ae0416044f538f50d2706f93b395601663b744b095b084f5
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/settingregistry@npm:^4.0.0, @jupyterlab/settingregistry@npm:^4.4.4":
   version: 4.4.4
   resolution: "@jupyterlab/settingregistry@npm:4.4.4"
@@ -2702,6 +2785,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/settingregistry@npm:^4.4.5":
+  version: 4.4.5
+  resolution: "@jupyterlab/settingregistry@npm:4.4.5"
+  dependencies:
+    "@jupyterlab/nbformat": ^4.4.5
+    "@jupyterlab/statedb": ^4.4.5
+    "@lumino/commands": ^2.3.2
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/signaling": ^2.1.4
+    "@rjsf/utils": ^5.13.4
+    ajv: ^8.12.0
+    json5: ^2.2.3
+  peerDependencies:
+    react: ">=16"
+  checksum: b8828b12bb474d2202f6e8263b033a3e8f42ba155dbdd8ad040a76ca9dbf5f8c6861dc834a5c1e2045644fced5eaa34ab8ec9ed32f6a39f0b6c019ef42c55112
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/statedb@npm:^4.4.3":
   version: 4.4.3
   resolution: "@jupyterlab/statedb@npm:4.4.3"
@@ -2725,6 +2827,19 @@ __metadata:
     "@lumino/properties": ^2.0.3
     "@lumino/signaling": ^2.1.4
   checksum: 9b98f6cebdb812f3d586fd55a8ca4ac0198aa9f3492b2dc7d844209b58992ae63e432a74139e18e29e49094f86770ac5c10cb6d6e44b4ed97b47997b08220a80
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/statedb@npm:^4.4.5":
+  version: 4.4.5
+  resolution: "@jupyterlab/statedb@npm:4.4.5"
+  dependencies:
+    "@lumino/commands": ^2.3.2
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/properties": ^2.0.3
+    "@lumino/signaling": ^2.1.4
+  checksum: eab9e3359d060aac929d3c0aa62bbfa077d2725c8ffbaa5b6eba5eae86da0f8d12d2e82f8802d16a370a159bb1f9d7edb6ec50c64abfd237fb7216672b1fc9f2
   languageName: node
   linkType: hard
 
@@ -2840,6 +2955,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/translation@npm:^4.4.5":
+  version: 4.4.5
+  resolution: "@jupyterlab/translation@npm:4.4.5"
+  dependencies:
+    "@jupyterlab/coreutils": ^6.4.5
+    "@jupyterlab/rendermime-interfaces": ^3.12.5
+    "@jupyterlab/services": ^7.4.5
+    "@jupyterlab/statedb": ^4.4.5
+    "@lumino/coreutils": ^2.2.1
+  checksum: edc449d84b739d0bb861fcb07d330c71d78cdec5b90034e349212aa711e9dc401d72dfd7d2bf7b632fe0ecfaec045c42930fbbcde409f6cb2c1ce450fabfab3a
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/ui-components@npm:^4.0.0":
   version: 4.4.3
   resolution: "@jupyterlab/ui-components@npm:4.4.3"
@@ -2899,6 +3027,37 @@ __metadata:
   peerDependencies:
     react: ^18.2.0
   checksum: 31961c53ea3d866c69a2a9bbb8d5ec1cc4a818301ae7e0abd086b42b5af08ae38e86691e7df5fedf4eb482e7ddfe098d4b03c3129d0e68c8f1aa581c8f98953f
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/ui-components@npm:^4.4.5":
+  version: 4.4.5
+  resolution: "@jupyterlab/ui-components@npm:4.4.5"
+  dependencies:
+    "@jupyter/react-components": ^0.16.6
+    "@jupyter/web-components": ^0.16.6
+    "@jupyterlab/coreutils": ^6.4.5
+    "@jupyterlab/observables": ^5.4.5
+    "@jupyterlab/rendermime-interfaces": ^3.12.5
+    "@jupyterlab/translation": ^4.4.5
+    "@lumino/algorithm": ^2.0.3
+    "@lumino/commands": ^2.3.2
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/messaging": ^2.0.3
+    "@lumino/polling": ^2.1.4
+    "@lumino/properties": ^2.0.3
+    "@lumino/signaling": ^2.1.4
+    "@lumino/virtualdom": ^2.0.3
+    "@lumino/widgets": ^2.7.1
+    "@rjsf/core": ^5.13.4
+    "@rjsf/utils": ^5.13.4
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    typestyle: ^2.0.4
+  peerDependencies:
+    react: ^18.2.0
+  checksum: 0edc8857042ee6285ba418c5e5d486dd236845e7d02da1f4fa4e957ab33747c1632646e20af616d9ba39615b929f3f36a63abd5580577fc356503f4a4210e6e5
   languageName: node
   linkType: hard
 
@@ -3346,6 +3505,7 @@ __metadata:
     "@jupyterlab/apputils": ^4.0.0
     "@jupyterlab/builder": ">=3.6.8 <5.0.0"
     "@jupyterlab/coreutils": ^6.0.0
+    "@jupyterlab/launcher": ^4.0.0
     "@jupyterlab/mainmenu": ^4.0.0
     "@jupyterlab/services": ^7.0.0
     "@jupyterlab/settingregistry": ^4.0.0


### PR DESCRIPTION
Aims to resolve #281 

- Adds a launcher tile with an icon, for Gator
<img width="394" height="202" alt="Screenshot 2025-07-23 at 4 25 12 PM" src="https://github.com/user-attachments/assets/0bd65f91-46ae-4e59-b0ec-4ee8e1d6fb8b" />

- Side effect: Also adds an icon to the settings option 
<img width="275" height="37" alt="Screenshot 2025-07-23 at 4 25 04 PM" src="https://github.com/user-attachments/assets/5acfcc73-9be9-47c2-a619-fc071ac3f250" />
