### PR TITLE
Minor updates to release flow recommendations

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@ This guide explains how to release mamba_gator packages.
 For testing releases, use the dedicated Test PyPI workflow:
 
 1. **Prepare the release**:
+   - Update the changelog in `README.md`
    - Update version in `pyproject.toml` and `package.json`
    - Commit and push changes
    - Create and push a git tag (e.g., `v5.2.1`)
@@ -23,6 +24,7 @@ For testing releases, use the dedicated Test PyPI workflow:
 For production releases, use the dedicated PyPI workflow:
 
 1. **Prepare the release** (Only necessary if not previously followed in the TestPyPI workflow):
+   - Update the changelog in `README.md`
    - Update version in `pyproject.toml` and `package.json`
    - Commit and push changes
    - Create and push a git tag (e.g., `v5.2.1`)
@@ -80,7 +82,7 @@ For production releases, use the dedicated PyPI workflow:
 The project uses semantic versioning (X.Y.Z):
 
 - **X**: Major version (breaking changes)
-- **Y**: Minor version (new features, backward compatible)x 
+- **Y**: Minor version (new features, backward compatible)
 - **Z**: Patch version (bug fixes, backward compatible)
 
 ### Development Versions

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -57,7 +57,7 @@ For production releases, use the dedicated PyPI workflow:
    git tag v5.2.1
 
    # Push changes and tag
-   git push upstream main --tags
+   git push origin main --tags
    ```
 
 3. **Test Release** (GitHub Actions):
@@ -74,7 +74,7 @@ For production releases, use the dedicated PyPI workflow:
    # Example: Change from "5.2.1" to "5.2.2.dev0"
    git add pyproject.toml package.json
    git commit -m "Bump version to 5.2.2.dev0"
-   git push upstream main
+   git push origin main
    ```
 
 ## Version Management

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -38,21 +38,24 @@ For production releases, use the dedicated PyPI workflow:
 
 ### Step-by-Step Process
 
-1. **Update Version** (Manual):
+1. **Update Version and Changelog** (Manual):
    ```bash
+   # Update Changelog in README.md
    # Update version in pyproject.toml and package.json
    # Example: Change from "5.2.1.dev0" to "5.2.1"
    ```
 
 2. **Commit and Tag**:
    ```bash
-   git add pyproject.toml package.json
+   # Commit changes
+   git add pyproject.toml package.json README.md
    git commit -m "Bump version to 5.2.1"
-   git push origin main
    
-   # Create and push tag
+   # Create tag
    git tag v5.2.1
-   git push origin v5.2.1
+
+   # Push changes and tag
+   git push upstream main --tags
    ```
 
 3. **Test Release** (GitHub Actions):
@@ -69,7 +72,7 @@ For production releases, use the dedicated PyPI workflow:
    # Example: Change from "5.2.1" to "5.2.2.dev0"
    git add pyproject.toml package.json
    git commit -m "Bump version to 5.2.2.dev0"
-   git push origin main
+   git push upstream main
    ```
 
 ## Version Management
@@ -77,7 +80,7 @@ For production releases, use the dedicated PyPI workflow:
 The project uses semantic versioning (X.Y.Z):
 
 - **X**: Major version (breaking changes)
-- **Y**: Minor version (new features, backward compatible)
+- **Y**: Minor version (new features, backward compatible)x 
 - **Z**: Patch version (bug fixes, backward compatible)
 
 ### Development Versions


### PR DESCRIPTION
This PR 
- adds the changelog to the release process recommendation. We can update the changelog when bumping the version, for a cleaner workflow.
- modifies branch name to `upstream` since many times `origin` is our fork of the repo.