### PR TITLE
Moving clone, export and remove functionality to per environment

### DIFF
--- a/packages/common/src/CondaEnvWidget.tsx
+++ b/packages/common/src/CondaEnvWidget.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import './icon';
 import { NbConda } from './components/NbConda';
 import { IEnvironmentManager } from './tokens';
+import { CommandRegistry } from '@lumino/commands';
 
 /**
  * Widget size interface
@@ -24,9 +25,10 @@ interface ISize {
  * Widget encapsulating the Conda Environments & Packages Manager
  */
 export class CondaEnvWidget extends ReactWidget {
-  constructor(envModel: IEnvironmentManager) {
+  constructor(envModel: IEnvironmentManager, commands: CommandRegistry) {
     super();
     this._envModel = envModel;
+    this._commands = commands;
   }
 
   protected onResize(msg: Widget.ResizeMessage): void {
@@ -46,6 +48,7 @@ export class CondaEnvWidget extends ReactWidget {
             height={size.height}
             width={size.width}
             model={this._envModel}
+            commands={this._commands}
           />
         )}
       </UseSignal>

--- a/packages/common/src/components/CondaEnvItem.tsx
+++ b/packages/common/src/components/CondaEnvItem.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
-import { style } from 'typestyle';
+import { useEffect } from 'react';
+import { classes, style } from 'typestyle';
+import { Menu } from '@lumino/widgets';
+import { CommandRegistry } from '@lumino/commands';
+import { ToolbarButtonComponent } from '@jupyterlab/ui-components';
 import { GlobalStyle } from './globalStyles';
+import { ellipsisVerticalIcon, cloneIcon } from '../icon';
+import { downloadIcon, deleteIcon } from '@jupyterlab/ui-components';
 
 /**
  * Environment item properties
@@ -18,7 +24,32 @@ export interface IEnvItemProps {
    * Environment item click handler
    */
   onClick(name: string): void;
+  onClone(name: string): void;
+  onRemove(name: string): void;
+  onExport(name: string): void;
+  onRefresh(): void;
+  commands: CommandRegistry;
 }
+
+export const createMenu = (
+  commands: CommandRegistry,
+  envName: string
+): Menu => {
+  const menu = new Menu({ commands });
+  menu.addItem({
+    command: 'gator-lab:remove-env',
+    args: { name: envName }
+  });
+  menu.addItem({
+    command: 'gator-lab:clone-env',
+    args: { name: envName }
+  });
+  menu.addItem({
+    command: 'gator-lab:export-env',
+    args: { name: envName }
+  });
+  return menu;
+};
 
 /**
  * Environment item component
@@ -26,12 +57,81 @@ export interface IEnvItemProps {
 export const CondaEnvItem: React.FunctionComponent<IEnvItemProps> = (
   props: IEnvItemProps
 ) => {
+  useEffect(() => {
+    console.log('commands instance:', props.commands);
+    console.log('hasCommand is function?', typeof props.commands.hasCommand);
+
+    if (!props.commands.hasCommand('gator-lab:clone-env')) {
+      props.commands.addCommand('gator-lab:clone-env', {
+        icon: cloneIcon,
+        label: 'Clone',
+        execute: async args => {
+          const name = args['name'] as string;
+          console.log('cloning environment:', name);
+          props.onClone(name);
+          props.onRefresh();
+        }
+      });
+    }
+
+    if (!props.commands.hasCommand('gator-lab:remove-env')) {
+      props.commands.addCommand('gator-lab:remove-env', {
+        icon: deleteIcon,
+        label: 'Remove',
+        execute: async args => {
+          const name = args['name'] as string;
+          console.log('removing environment:', name);
+          props.onRemove(name);
+          props.onRefresh();
+        }
+      });
+    }
+
+    if (!props.commands.hasCommand('gator-lab:export-env')) {
+      props.commands.addCommand('gator-lab:export-env', {
+        icon: downloadIcon,
+        label: 'Export',
+        execute: async args => {
+          const name = args['name'] as string;
+          console.log('exporting environment:', name);
+          props.onExport(name);
+        }
+      });
+    }
+  }, [props.commands]);
+
+  const iconRef = React.useRef<HTMLDivElement>(null);
+
+  const handleItemClick = () => {
+    props.onClick(props.name);
+  };
+
+  const handleMenuClick = (event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const rect = iconRef.current?.getBoundingClientRect();
+    const x = rect?.left ?? event.clientX;
+    const y = (rect?.bottom ?? event.clientY) + 4;
+
+    const menu = createMenu(props.commands, props.name);
+    menu.open(x, y);
+  };
+
   return (
     <div
       className={props.selected ? Style.SelectedItem : Style.Item}
-      onClick={(): void => props.onClick(props.name)}
+      onClick={handleItemClick}
     >
-      {props.name}
+      <span>{props.name}</span>
+      <div
+        className={classes('jp-CondaEnvKebab')}
+        ref={iconRef}
+        onClick={handleMenuClick}
+        title="More actions"
+      >
+        <ToolbarButtonComponent icon={ellipsisVerticalIcon} />
+      </div>
     </div>
   );
 };
@@ -39,7 +139,10 @@ export const CondaEnvItem: React.FunctionComponent<IEnvItemProps> = (
 namespace Style {
   export const Item = style(GlobalStyle.ListItem, {
     padding: '2px 0 5px 5px',
-
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
     $nest: {
       '&:hover': {
         backgroundColor: 'var(--jp-layout-color2)',
@@ -59,7 +162,6 @@ namespace Style {
 
     $nest: {
       '&::after': {
-        content: "' '",
         display: 'inline-block',
         padding: '0 5px',
         width: 0,
@@ -70,5 +172,12 @@ namespace Style {
           'calc(var(--jp-ui-font-size1) / 2) solid var(--jp-ui-inverse-font-color1)'
       }
     }
+  });
+
+  export const Kebab = style({
+    cursor: 'pointer',
+    marginLeft: 'auto',
+    padding: '0 5px',
+    justifyContent: 'flex-end'
   });
 }

--- a/packages/common/src/components/CondaEnvItem.tsx
+++ b/packages/common/src/components/CondaEnvItem.tsx
@@ -58,16 +58,12 @@ export const CondaEnvItem: React.FunctionComponent<IEnvItemProps> = (
   props: IEnvItemProps
 ) => {
   useEffect(() => {
-    console.log('commands instance:', props.commands);
-    console.log('hasCommand is function?', typeof props.commands.hasCommand);
-
     if (!props.commands.hasCommand('gator-lab:clone-env')) {
       props.commands.addCommand('gator-lab:clone-env', {
         icon: cloneIcon,
         label: 'Clone',
         execute: async args => {
           const name = args['name'] as string;
-          console.log('cloning environment:', name);
           props.onClone(name);
           props.onRefresh();
         }
@@ -80,7 +76,6 @@ export const CondaEnvItem: React.FunctionComponent<IEnvItemProps> = (
         label: 'Remove',
         execute: async args => {
           const name = args['name'] as string;
-          console.log('removing environment:', name);
           props.onRemove(name);
           props.onRefresh();
         }
@@ -93,7 +88,6 @@ export const CondaEnvItem: React.FunctionComponent<IEnvItemProps> = (
         label: 'Export',
         execute: async args => {
           const name = args['name'] as string;
-          console.log('exporting environment:', name);
           props.onExport(name);
         }
       });

--- a/packages/common/src/components/CondaEnvList.tsx
+++ b/packages/common/src/components/CondaEnvList.tsx
@@ -4,6 +4,7 @@ import { CONDA_ENVIRONMENT_PANEL_ID } from '../constants';
 import { Conda } from '../tokens';
 import { CondaEnvItem } from './CondaEnvItem';
 import { CondaEnvToolBar, ENVIRONMENT_TOOLBAR_HEIGHT } from './CondaEnvToolBar';
+import { CommandRegistry } from '@lumino/commands';
 
 export const ENVIRONMENT_PANEL_WIDTH = 250;
 
@@ -38,7 +39,7 @@ export interface IEnvListProps {
   /**
    * Environment clone handler
    */
-  onClone(): void;
+  onClone(name: string): void;
   /**
    * Environment import handler
    */
@@ -46,7 +47,7 @@ export interface IEnvListProps {
   /**
    * Environment export handler
    */
-  onExport(): void;
+  onExport(name: string): void;
   /**
    * Refresh environment handler
    */
@@ -54,7 +55,8 @@ export interface IEnvListProps {
   /**
    * Environment remove handler
    */
-  onRemove(): void;
+  onRemove(name: string): void;
+  commands: CommandRegistry;
 }
 
 /**
@@ -77,6 +79,11 @@ export const CondaEnvList: React.FunctionComponent<IEnvListProps> = (
         key={env.name}
         selected={props.selected ? env.name === props.selected : false}
         onClick={props.onSelectedChange}
+        onClone={props.onClone}
+        onRemove={props.onRemove}
+        onExport={props.onExport}
+        onRefresh={props.onRefresh}
+        commands={props.commands}
       />
     );
   });

--- a/packages/common/src/components/CondaEnvToolBar.tsx
+++ b/packages/common/src/components/CondaEnvToolBar.tsx
@@ -1,11 +1,6 @@
 import { ToolbarButtonComponent } from '@jupyterlab/apputils';
-import {
-  addIcon,
-  deleteIcon,
-  downloadIcon,
-  fileUploadIcon
-} from '@jupyterlab/ui-components';
-import { cloneIcon, syncAltIcon } from '../icon';
+import { addIcon, fileUploadIcon } from '@jupyterlab/ui-components';
+import { syncAltIcon } from '../icon';
 import * as React from 'react';
 import { style } from 'typestyle';
 import { CONDA_ENVIRONMENT_TOOLBAR_CLASS } from '../constants';
@@ -32,7 +27,7 @@ export interface ICondaEnvToolBarProps {
   /**
    * Clone environment handler
    */
-  onClone(): void;
+  onClone(name: string): void;
   /**
    * Import environment handler
    */
@@ -40,7 +35,7 @@ export interface ICondaEnvToolBarProps {
   /**
    * Export environment handler
    */
-  onExport(): void;
+  onExport(name: string): void;
   /**
    * Refresh environment handler
    */
@@ -48,7 +43,7 @@ export interface ICondaEnvToolBarProps {
   /**
    * Remove environment handler
    */
-  onRemove(): void;
+  onRemove(name: string): void;
 }
 
 export const CondaEnvToolBar = (props: ICondaEnvToolBarProps): JSX.Element => {
@@ -56,13 +51,6 @@ export const CondaEnvToolBar = (props: ICondaEnvToolBarProps): JSX.Element => {
     <div className={Style.NoGrow}>
       <div className={Style.Title}>
         <span className={Style.Grow}>Conda environments</span>
-        <div data-loading={props.isPending}>
-          <ToolbarButtonComponent
-            icon={syncAltIcon}
-            tooltip="Refresh environments"
-            onClick={props.onRefresh}
-          />
-        </div>
       </div>
       <div
         className={`lm-Widget jp-Toolbar ${CONDA_ENVIRONMENT_TOOLBAR_CLASS}`}
@@ -73,27 +61,17 @@ export const CondaEnvToolBar = (props: ICondaEnvToolBarProps): JSX.Element => {
           onClick={props.onCreate}
         />
         <ToolbarButtonComponent
-          icon={cloneIcon}
-          tooltip="Clone"
-          onClick={props.onClone}
-          enabled={!props.isBase}
-        />
-        <ToolbarButtonComponent
           icon={fileUploadIcon}
           tooltip="Import"
           onClick={props.onImport}
         />
-        <ToolbarButtonComponent
-          icon={downloadIcon}
-          tooltip="Export"
-          onClick={props.onExport}
-        />
-        <ToolbarButtonComponent
-          icon={deleteIcon}
-          tooltip="Remove"
-          onClick={props.onRemove}
-          enabled={!props.isBase}
-        />
+        <div data-loading={props.isPending}>
+          <ToolbarButtonComponent
+            icon={syncAltIcon}
+            tooltip="Refresh environments"
+            onClick={props.onRefresh}
+          />
+        </div>
       </div>
     </div>
   );

--- a/packages/common/src/components/NbConda.tsx
+++ b/packages/common/src/components/NbConda.tsx
@@ -5,6 +5,7 @@ import { style } from 'typestyle';
 import { Conda, IEnvironmentManager } from '../tokens';
 import { CondaEnvList, ENVIRONMENT_PANEL_WIDTH } from './CondaEnvList';
 import { CondaPkgPanel } from './CondaPkgPanel';
+import { CommandRegistry } from '@lumino/commands';
 
 /**
  * Jupyter Conda Component properties
@@ -22,6 +23,7 @@ export interface ICondaEnvProps {
    * Environment manager
    */
   model: IEnvironmentManager;
+  commands: CommandRegistry;
 }
 
 /**
@@ -139,10 +141,10 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
     }
   }
 
-  async handleCloneEnvironment(): Promise<void> {
+  async handleCloneEnvironment(name: string): Promise<void> {
     let toastId = '';
     try {
-      const environmentName = this.state.currentEnvironment;
+      const environmentName = name ?? this.state.currentEnvironment;
       if (!environmentName) {
         return;
       }
@@ -276,9 +278,9 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
     }
   }
 
-  async handleExportEnvironment(): Promise<void> {
+  async handleExportEnvironment(name: string): Promise<void> {
     try {
-      const environmentName = this.state.currentEnvironment;
+      const environmentName = name ?? this.state.currentEnvironment;
       if (!environmentName) {
         return;
       }
@@ -311,10 +313,10 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
     await this.loadEnvironments();
   }
 
-  async handleRemoveEnvironment(): Promise<void> {
+  async handleRemoveEnvironment(name: string): Promise<void> {
     let toastId = '';
     try {
-      const environmentName = this.state.currentEnvironment;
+      const environmentName = name ?? this.state.currentEnvironment;
       if (!environmentName) {
         return;
       }
@@ -414,6 +416,7 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
           onExport={this.handleExportEnvironment}
           onRefresh={this.handleRefreshEnvironment}
           onRemove={this.handleRemoveEnvironment}
+          commands={this.props.commands}
         />
         <CondaPkgPanel
           height={this.props.height}

--- a/packages/common/src/icon.ts
+++ b/packages/common/src/icon.ts
@@ -5,7 +5,7 @@ import cartArrowDownSvgstr from '../style/cart-arrow-down.svg';
 import undoSvgstr from '../style/undo.svg';
 import cloneSvgstr from '../style/clone.svg';
 import syncAltSvgstr from '../style/sync-alt.svg';
-
+import ellipsisVerticalSvgstr from '../style/ellipsis-vertical.svg';
 import { IconDefinition, library } from '@fortawesome/fontawesome-svg-core';
 import {
   faClone,
@@ -68,4 +68,9 @@ export const cloneIcon = new LabIcon({
 export const syncAltIcon = new LabIcon({
   name: '@mamba-org/gator-lab:sync-alt',
   svgstr: syncAltSvgstr
+});
+
+export const ellipsisVerticalIcon = new LabIcon({
+  name: '@mamba-org/gator-lab:ellipsis-vertical',
+  svgstr: ellipsisVerticalSvgstr
 });

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,5 +1,5 @@
 export { CondaEnvWidget } from './CondaEnvWidget';
 export * from './constants';
-export { condaIcon } from './icon';
+export * from './icon';
 export { CondaEnvironments } from './services';
 export { Conda, IEnvironmentManager } from './tokens';

--- a/packages/common/style/ellipsis-vertical.svg
+++ b/packages/common/style/ellipsis-vertical.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640">
+<!--!Font Awesome Free v7.0.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
+    <path d="M320 208C289.1 208 264 182.9 264 152C264 121.1 289.1 96 320 96C350.9 96 376 121.1 376 152C376 182.9 350.9 208 320 208zM320 432C350.9 432 376 457.1 376 488C376 518.9 350.9 544 320 544C289.1 544 264 518.9 264 488C264 457.1 289.1 432 320 432zM376 320C376 350.9 350.9 376 320 376C289.1 376 264 350.9 264 320C264 289.1 289.1 264 320 264C350.9 264 376 289.1 376 320z">
+    </path>
+</svg>

--- a/packages/labextension/src/index.ts
+++ b/packages/labextension/src/index.ts
@@ -94,7 +94,7 @@ async function activateCondaEnv(
 
       if (!condaWidget || condaWidget.isDisposed) {
         condaWidget = new MainAreaWidget({
-          content: new CondaEnvWidget(model) as any
+          content: new CondaEnvWidget(model, commands) as any
         });
         condaWidget.addClass(CONDA_WIDGET_CLASS);
         condaWidget.id = pluginNamespace;

--- a/packages/navigator/src/plugins/navigator/index.ts
+++ b/packages/navigator/src/plugins/navigator/index.ts
@@ -29,14 +29,14 @@ const plugin: JupyterFrontEndPlugin<void> = {
     // Request listing available package as quickly as possible
     Private.loadPackages(model);
 
-    const content = new CondaEnvWidget(model);
+    const content = new CondaEnvWidget(model, app.commands);
     content.addClass(CONDA_WIDGET_CLASS);
     content.id = DOMUtils.createDomID();
     content.title.label = 'Packages';
     content.title.caption = 'Conda Packages Manager';
     content.title.icon = condaIcon;
     const envModel = new CondaEnvironments();
-    const widget = new CondaEnvWidget(envModel) as any;
+    const widget = new CondaEnvWidget(envModel, app.commands) as any;
     widget.title.closable = false;
     app.shell.add(widget, 'main');
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15077,21 +15077,21 @@ __metadata:
 
 "typescript@patch:typescript@>=3 < 6#~builtin<compat/typescript>":
   version: 5.8.3
-  resolution: "typescript@patch:typescript@npm%3A5.8.3#~builtin<compat/typescript>::version=5.8.3&hash=5786d5"
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#~builtin<compat/typescript>::version=5.8.3&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: f1743b6850976b3debf7cbd53d2bc0b67e75d47eb6410db564c8bb475e92a8a48f8a3fcd14d89cf93426835281c31a8f8a94dad90be4dc899279a898532ba97f
+  checksum: 1b503525a88ff0ff5952e95870971c4fb2118c17364d60302c21935dedcd6c37e6a0a692f350892bafcef6f4a16d09073fe461158547978d2f16fbe4cb18581c
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@~5.0.2#~builtin<compat/typescript>":
   version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: d26b6ba97b6d163c55dbdffd9bbb4c211667ebebc743accfeb2c8c0154aace7afd097b51165a72a5bad2cf65a4612259344ff60f8e642362aa1695c760d303ac
+  checksum: bb309d320c59a26565fb3793dba550576ab861018ff3fd1b7fccabbe46ae4a35546bc45f342c0a0b6f265c801ccdf64ffd68f548f117ceb7f0eac4b805cd52a9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR more cleanly reuses and updates the existing clone(), remove() and export() functionality to allow for them to be inline with a corresponding conda environment item.

<img width="525" height="441" alt="kebab" src="https://github.com/user-attachments/assets/8b6b4785-510a-41ab-813b-3653e5846011" />


https://github.com/user-attachments/assets/5c75ba82-4225-43a9-93ee-c165b2646bbc

