### PR TITLE
Add border and box shadow to environment items

### DIFF
--- a/packages/common/src/components/CondaEnvItem.tsx
+++ b/packages/common/src/components/CondaEnvItem.tsx
@@ -38,21 +38,29 @@ export const CondaEnvItem: React.FunctionComponent<IEnvItemProps> = (
 
 namespace Style {
   export const Item = style(GlobalStyle.ListItem, {
-    padding: '2px 0 5px 5px',
-
+    padding: '6px 8px',
+    backgroundColor: 'var(--jp-layout-color1)',
+    border: '1px solid var(--jp-border-color2)',
+    borderRadius: '4px',
+    marginBottom: '4px',
+    boxShadow: '0 1px 2px rgba(0, 0, 0, 0.05)',
     $nest: {
       '&:hover': {
         backgroundColor: 'var(--jp-layout-color2)',
-        border: '1px solid var(--jp-border-color2)'
+        borderColor: 'var(--jp-border-color1)',
+        boxShadow: '0 2px 4px rgba(0, 0, 0, 0.08)'
       }
     }
   });
 
   export const SelectedItem = style(GlobalStyle.ListItem, {
-    padding: '2px 0 5px 5px',
+    padding: '6px 8px',
     backgroundColor: 'var(--jp-brand-color1)',
     color: 'var(--jp-ui-inverse-font-color1)',
     border: '1px solid var(--jp-brand-color1)',
+    borderRadius: '4px',
+    marginBottom: '4px',
+    boxShadow: '0 2px 4px rgba(0, 0, 0, 0.12)',
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',


### PR DESCRIPTION
This PR adds CSS to style environment items so they are easily more distinguishable from one another.

On main it currently looks like:
<img width="252" height="295" alt="border_boxShadow" src="https://github.com/user-attachments/assets/6bde648b-190e-4e30-924b-9683714813f2" />


On top of the work for the environment item actions it looks like:
<img width="250" height="305" alt="border_boxShadow_kebab" src="https://github.com/user-attachments/assets/19a6414b-583b-4d0e-8fe5-2fdc5efd6183" />

