### PR TITLE
Update UI layout of title and refresh environments button

### DIFF
--- a/packages/common/src/components/CondaEnvList.tsx
+++ b/packages/common/src/components/CondaEnvList.tsx
@@ -41,10 +41,6 @@ export interface IEnvListProps {
    * Environment import handler
    */
   onImport(): void;
-  /**
-   * Refresh environment handler
-   */
-  onRefresh(): void;
   commands: CommandRegistry;
 }
 
@@ -80,7 +76,6 @@ export const CondaEnvList: React.FunctionComponent<IEnvListProps> = (
         isPending={props.isPending}
         onCreate={props.onCreate}
         onImport={props.onImport}
-        onRefresh={props.onRefresh}
       />
       <div
         id={CONDA_ENVIRONMENT_PANEL_ID}

--- a/packages/common/src/components/CondaEnvToolBar.tsx
+++ b/packages/common/src/components/CondaEnvToolBar.tsx
@@ -33,7 +33,7 @@ export const CondaEnvToolBar = (props: ICondaEnvToolBarProps): JSX.Element => {
   return (
     <div className={Style.NoGrow}>
       <div
-        className={`lm-Widget jp-Toolbar ${CONDA_ENVIRONMENT_TOOLBAR_CLASS}`}
+        className={`lm-Widget jp-Toolbar ${CONDA_ENVIRONMENT_TOOLBAR_CLASS} ${Style.Toolbar}`}
       >
         <ToolbarButtonComponent
           icon={addIcon}
@@ -54,5 +54,9 @@ namespace Style {
   export const NoGrow = style({
     flexGrow: 0,
     flexShrink: 0
+  });
+  export const Toolbar = style({
+    alignItems: 'center',
+    height: ENVIRONMENT_TOOLBAR_HEIGHT
   });
 }

--- a/packages/common/src/components/CondaEnvToolBar.tsx
+++ b/packages/common/src/components/CondaEnvToolBar.tsx
@@ -1,6 +1,5 @@
 import { ToolbarButtonComponent } from '@jupyterlab/apputils';
 import { addIcon, fileUploadIcon } from '@jupyterlab/ui-components';
-import { syncAltIcon } from '../icon';
 import * as React from 'react';
 import { style } from 'typestyle';
 import { CONDA_ENVIRONMENT_TOOLBAR_CLASS } from '../constants';
@@ -28,18 +27,11 @@ export interface ICondaEnvToolBarProps {
    * Import environment handler
    */
   onImport(): void;
-  /**
-   * Refresh environment handler
-   */
-  onRefresh(): void;
 }
 
 export const CondaEnvToolBar = (props: ICondaEnvToolBarProps): JSX.Element => {
   return (
     <div className={Style.NoGrow}>
-      <div className={Style.Title}>
-        <span className={Style.Grow}>Conda environments</span>
-      </div>
       <div
         className={`lm-Widget jp-Toolbar ${CONDA_ENVIRONMENT_TOOLBAR_CLASS}`}
       >
@@ -53,41 +45,14 @@ export const CondaEnvToolBar = (props: ICondaEnvToolBarProps): JSX.Element => {
           tooltip="Import"
           onClick={props.onImport}
         />
-        <div data-loading={props.isPending}>
-          <ToolbarButtonComponent
-            icon={syncAltIcon}
-            tooltip="Refresh environments"
-            onClick={props.onRefresh}
-          />
-        </div>
       </div>
     </div>
   );
 };
 
 namespace Style {
-  export const Grow = style({
-    flexGrow: 1,
-    flexShrink: 1
-  });
-
   export const NoGrow = style({
     flexGrow: 0,
     flexShrink: 0
-  });
-
-  export const Spin = style({
-    animation: 'spin 1s linear infinite'
-  });
-
-  export const Title = style({
-    color: 'var(--jp-ui-font-color1)',
-    textAlign: 'center',
-    fontWeight: 'bold',
-    fontSize: 'var(--jp-ui-font-size2)',
-    height: ENVIRONMENT_TOOLBAR_HEIGHT,
-    display: 'flex',
-    flex: '0 0 auto',
-    flexDirection: 'row'
   });
 }

--- a/packages/common/src/components/NbConda.tsx
+++ b/packages/common/src/components/NbConda.tsx
@@ -267,7 +267,7 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
     return (
       <div className={Style.HeaderContainer}>
         <div className={Style.Grow}>
-          <div className={Style.Title}>Conda Environments</div>
+          <div className={Style.Title}>Environments</div>
           <div className={Style.RefreshButton}>
             <div
               data-loading={this.state.isLoading}
@@ -278,7 +278,7 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
                 tooltip="Refresh Environments"
                 onClick={this.handleRefreshEnvironment}
                 label="Refresh Environments"
-                className={Style.RefeshEnvsIconLabelGap}
+                className={Style.RefreshEnvsIconLabelGap}
               />
             </div>
           </div>
@@ -323,13 +323,16 @@ namespace Style {
 
   export const Grow = style({
     display: 'flex',
-    alignItems: 'baseline',
+    alignItems: 'center',
     justifyContent: 'space-between',
     padding: '4px 8px',
     backgroundColor: 'var(--jp-layout-color1)'
   });
 
   export const Title = style({
+    display: 'flex',
+    alignItems: 'center',
+    paddingLeft: '15px',
     color: 'var(--jp-ui-font-color1)',
     fontWeight: 600,
     fontSize: 'var(--jp-ui-font-size2)',
@@ -350,7 +353,7 @@ namespace Style {
     gap: '6px'
   });
 
-  export const RefeshEnvsIconLabelGap = style({
+  export const RefreshEnvsIconLabelGap = style({
     $nest: {
       '.jp-ToolbarButtonComponent-label': {
         marginLeft: '6px'

--- a/packages/common/src/components/NbConda.tsx
+++ b/packages/common/src/components/NbConda.tsx
@@ -6,6 +6,8 @@ import { style } from 'typestyle';
 import { Conda, IEnvironmentManager } from '../tokens';
 import { CondaEnvList, ENVIRONMENT_PANEL_WIDTH } from './CondaEnvList';
 import { CondaPkgPanel } from './CondaPkgPanel';
+import { ToolbarButtonComponent } from '@jupyterlab/ui-components';
+import { syncAltIcon } from '../icon';
 
 /**
  * Jupyter Conda Component properties
@@ -263,25 +265,42 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
 
   render(): JSX.Element {
     return (
-      <div className={Style.Panel}>
-        <CondaEnvList
-          height={this.props.height}
-          isPending={this.state.isLoading}
-          environments={this.state.environments}
-          selected={this.state.currentEnvironment}
-          onSelectedChange={this.handleEnvironmentChange}
-          onCreate={this.handleCreateEnvironment}
-          onImport={this.handleImportEnvironment}
-          onRefresh={this.handleRefreshEnvironment}
-          commands={this.props.commands}
-        />
-        <CondaPkgPanel
-          height={this.props.height}
-          width={this.props.width - ENVIRONMENT_PANEL_WIDTH}
-          packageManager={this.props.model.getPackageManager(
-            this.state.currentEnvironment
-          )}
-        />
+      <div className={Style.HeaderContainer}>
+        <div className={Style.Grow}>
+          <div className={Style.Title}>Conda Environments</div>
+          <div className={Style.RefreshButton}>
+            <div
+              data-loading={this.state.isLoading}
+              className={Style.RefreshInner}
+            >
+              <ToolbarButtonComponent
+                icon={syncAltIcon}
+                tooltip="Refresh Environments"
+                onClick={this.handleRefreshEnvironment}
+                label="Refresh Environments"
+              />
+            </div>
+          </div>
+        </div>
+        <div className={Style.Panel}>
+          <CondaEnvList
+            height={this.props.height}
+            isPending={this.state.isLoading}
+            environments={this.state.environments}
+            selected={this.state.currentEnvironment}
+            onSelectedChange={this.handleEnvironmentChange}
+            onCreate={this.handleCreateEnvironment}
+            onImport={this.handleImportEnvironment}
+            commands={this.props.commands}
+          />
+          <CondaPkgPanel
+            height={this.props.height}
+            width={this.props.width - ENVIRONMENT_PANEL_WIDTH}
+            packageManager={this.props.model.getPackageManager(
+              this.state.currentEnvironment
+            )}
+          />
+        </div>
       </div>
     );
   }
@@ -293,5 +312,40 @@ namespace Style {
     display: 'flex',
     flexDirection: 'row',
     borderCollapse: 'collapse'
+  });
+
+  export const HeaderContainer = style({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px'
+  });
+
+  export const Grow = style({
+    display: 'flex',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+    padding: '4px 8px',
+    backgroundColor: 'var(--jp-layout-color1)'
+  });
+
+  export const Title = style({
+    color: 'var(--jp-ui-font-color1)',
+    fontWeight: 600,
+    fontSize: 'var(--jp-ui-font-size2)',
+    lineHeight: 1.2,
+    whiteSpace: 'nowrap'
+  });
+
+  export const RefreshButton = style({
+    display: 'inline-flex',
+    alignItems: 'baseline',
+    gap: '8px',
+    whiteSpace: 'nowrap'
+  });
+
+  export const RefreshInner = style({
+    display: 'inline-flex',
+    alignItems: 'baseline',
+    gap: '6px'
   });
 }

--- a/packages/common/src/components/NbConda.tsx
+++ b/packages/common/src/components/NbConda.tsx
@@ -278,6 +278,7 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
                 tooltip="Refresh Environments"
                 onClick={this.handleRefreshEnvironment}
                 label="Refresh Environments"
+                className={Style.RefeshEnvsIconLabelGap}
               />
             </div>
           </div>
@@ -347,5 +348,13 @@ namespace Style {
     display: 'inline-flex',
     alignItems: 'baseline',
     gap: '6px'
+  });
+
+  export const RefeshEnvsIconLabelGap = style({
+    $nest: {
+      '.jp-ToolbarButtonComponent-label': {
+        marginLeft: '6px'
+      }
+    }
   });
 }

--- a/packages/common/style/index.css
+++ b/packages/common/style/index.css
@@ -82,15 +82,11 @@ button.jp-button-hide {
   display: none;
 }
 
-jp-button[data-loading="true"] > svg {
-  animation: gator-spin 1s linear infinite;
-}
-
 @keyframes gator-spin {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
 
-div[data-loading="true"] > jp-button[title="Refresh environments"] > svg {
+div[data-loading="true"] > jp-button[title="Refresh Environments"] > svg {
   animation: gator-spin 1s linear infinite;
 }


### PR DESCRIPTION
This PR is based off of #292.

- change layout of title and environment refresh button


https://github.com/user-attachments/assets/05ced632-be2a-4a0c-ab16-d2f96c01a755


- set height for environment toolbar to match packages toolbar
- add gap between icon and label for refresh envs button

Final look (note: blue border not a change in this pr, it is due to having tab selected the button):
<img width="1171" height="100" alt="style updates" src="https://github.com/user-attachments/assets/a70d17a0-6f69-42a4-b5fb-e2e7bbb88e82" />
