### PR TITLE
Feat: open main window with optional preselected environment name

### DIFF
--- a/packages/common/src/CondaEnvWidget.tsx
+++ b/packages/common/src/CondaEnvWidget.tsx
@@ -25,10 +25,17 @@ interface ISize {
  * Widget encapsulating the Conda Environments & Packages Manager
  */
 export class CondaEnvWidget extends ReactWidget {
+<<<<<<< HEAD
   constructor(envModel: IEnvironmentManager, commands: CommandRegistry) {
     super();
     this._envModel = envModel;
     this._commands = commands;
+=======
+  constructor(envModel: IEnvironmentManager, envName?: string) {
+    super();
+    this._envModel = envModel;
+    this._envName = envName;
+>>>>>>> 530570a (feature: open with env)
   }
 
   protected onResize(msg: Widget.ResizeMessage): void {
@@ -48,7 +55,11 @@ export class CondaEnvWidget extends ReactWidget {
             height={size.height}
             width={size.width}
             model={this._envModel}
+<<<<<<< HEAD
             commands={this._commands}
+=======
+            envName={this._envName}
+>>>>>>> 530570a (feature: open with env)
           />
         )}
       </UseSignal>

--- a/packages/common/src/CondaEnvWidget.tsx
+++ b/packages/common/src/CondaEnvWidget.tsx
@@ -25,17 +25,11 @@ interface ISize {
  * Widget encapsulating the Conda Environments & Packages Manager
  */
 export class CondaEnvWidget extends ReactWidget {
-<<<<<<< HEAD
-  constructor(envModel: IEnvironmentManager, commands: CommandRegistry) {
+  constructor(envModel: IEnvironmentManager, commands: CommandRegistry, envName?: string) {
     super();
     this._envModel = envModel;
     this._commands = commands;
-=======
-  constructor(envModel: IEnvironmentManager, envName?: string) {
-    super();
-    this._envModel = envModel;
     this._envName = envName;
->>>>>>> 530570a (feature: open with env)
   }
 
   protected onResize(msg: Widget.ResizeMessage): void {
@@ -55,11 +49,8 @@ export class CondaEnvWidget extends ReactWidget {
             height={size.height}
             width={size.width}
             model={this._envModel}
-<<<<<<< HEAD
             commands={this._commands}
-=======
             envName={this._envName}
->>>>>>> 530570a (feature: open with env)
           />
         )}
       </UseSignal>

--- a/packages/common/src/components/NbConda.tsx
+++ b/packages/common/src/components/NbConda.tsx
@@ -25,12 +25,11 @@ export interface ICondaEnvProps {
    * Environment manager
    */
   model: IEnvironmentManager;
-<<<<<<< HEAD
   commands: CommandRegistry;
-=======
-
+  /**
+   * Environment name
+   */
   envName?: string;
->>>>>>> 530570a (feature: open with env)
 }
 
 /**
@@ -53,6 +52,10 @@ export interface ICondaEnvState {
    * Is the environment list loading?
    */
   isLoading: boolean;
+  /**
+   * Environment name
+   */
+  envName?: string;
 }
 
 /** Top level React component for Jupyter Conda Manager */
@@ -70,8 +73,6 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
     this.handleCreateEnvironment = this.handleCreateEnvironment.bind(this);
     this.handleImportEnvironment = this.handleImportEnvironment.bind(this);
     this.handleRefreshEnvironment = this.handleRefreshEnvironment.bind(this);
-<<<<<<< HEAD
-
     this.props.model.refreshEnvs.connect(() => {
       this.loadEnvironments();
     });
@@ -81,14 +82,11 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
         this.setState({ currentEnvironment: undefined, channels: undefined });
       }
     });
-=======
-    this.handleRemoveEnvironment = this.handleRemoveEnvironment.bind(this);
 
     if (props.envName) {
       console.log("Setting current environment to", props.envName);
       this.handleEnvironmentChange(props.envName)
     } 
->>>>>>> 530570a (feature: open with env)
   }
 
   async handleEnvironmentChange(name: string): Promise<void> {

--- a/packages/common/src/components/NbConda.tsx
+++ b/packages/common/src/components/NbConda.tsx
@@ -66,7 +66,8 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
     this.state = {
       environments: [],
       currentEnvironment: undefined,
-      isLoading: false
+      isLoading: false,
+      envName: props.envName
     };
 
     this.handleEnvironmentChange = this.handleEnvironmentChange.bind(this);
@@ -92,7 +93,8 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
   async handleEnvironmentChange(name: string): Promise<void> {
     this.setState({
       currentEnvironment: name,
-      channels: await this.props.model.getChannels(name)
+      channels: await this.props.model.getChannels(name),
+      envName: name
     });
   }
 

--- a/packages/common/src/components/NbConda.tsx
+++ b/packages/common/src/components/NbConda.tsx
@@ -25,7 +25,12 @@ export interface ICondaEnvProps {
    * Environment manager
    */
   model: IEnvironmentManager;
+<<<<<<< HEAD
   commands: CommandRegistry;
+=======
+
+  envName?: string;
+>>>>>>> 530570a (feature: open with env)
 }
 
 /**
@@ -65,6 +70,7 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
     this.handleCreateEnvironment = this.handleCreateEnvironment.bind(this);
     this.handleImportEnvironment = this.handleImportEnvironment.bind(this);
     this.handleRefreshEnvironment = this.handleRefreshEnvironment.bind(this);
+<<<<<<< HEAD
 
     this.props.model.refreshEnvs.connect(() => {
       this.loadEnvironments();
@@ -75,6 +81,14 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
         this.setState({ currentEnvironment: undefined, channels: undefined });
       }
     });
+=======
+    this.handleRemoveEnvironment = this.handleRemoveEnvironment.bind(this);
+
+    if (props.envName) {
+      console.log("Setting current environment to", props.envName);
+      this.handleEnvironmentChange(props.envName)
+    } 
+>>>>>>> 530570a (feature: open with env)
   }
 
   async handleEnvironmentChange(name: string): Promise<void> {

--- a/packages/labextension/src/index.ts
+++ b/packages/labextension/src/index.ts
@@ -60,7 +60,8 @@ async function activateCondaEnv(
 
   commands.addCommand(command, {
     label: 'Conda Packages Manager',
-    execute: () => {
+    execute: (envNamePayload) => {
+      const { envName } = envNamePayload;
       app.restored.then(() => {
         let timeout = 0;
 
@@ -95,7 +96,7 @@ async function activateCondaEnv(
 
       if (!condaWidget || condaWidget.isDisposed) {
         condaWidget = new MainAreaWidget({
-          content: new CondaEnvWidget(model, commands) as any
+          content: new CondaEnvWidget(model, commands, envName as string) as any
         });
         condaWidget.addClass(CONDA_WIDGET_CLASS);
         condaWidget.id = pluginNamespace;

--- a/packages/labextension/src/index.ts
+++ b/packages/labextension/src/index.ts
@@ -96,7 +96,7 @@ async function activateCondaEnv(
 
       if (!condaWidget || condaWidget.isDisposed) {
         condaWidget = new MainAreaWidget({
-          content: new CondaEnvWidget(model, commands, envName as string) as any
+          content: new CondaEnvWidget(model, commands, envName as string | undefined) as any
         });
         condaWidget.addClass(CONDA_WIDGET_CLASS);
         condaWidget.id = pluginNamespace;


### PR DESCRIPTION
This PR update the existing `jupyter_conda:open-ui` command and adds an optional `envName` - If provided, the UI is shown with the provided environment.