### PR TITLE
Create button

### DIFF
--- a/packages/common/src/components/CondaEnvItem.tsx
+++ b/packages/common/src/components/CondaEnvItem.tsx
@@ -11,6 +11,10 @@ import { ellipsisVerticalIcon } from '../icon';
  */
 export interface IEnvItemProps {
   /**
+   * Is the environment the default one?
+   */
+  isDefault?: boolean;
+  /**
    * Environment name
    */
   name: string;
@@ -26,18 +30,21 @@ export interface IEnvItemProps {
 }
 
 export const createMenu = (
+  isDefault: boolean,
   commands: CommandRegistry,
   envName: string
 ): Menu => {
   const menu = new Menu({ commands });
-  menu.addItem({
-    command: 'gator-lab:remove-env',
-    args: { name: envName }
-  });
-  menu.addItem({
-    command: 'gator-lab:clone-env',
-    args: { name: envName }
-  });
+  if (!isDefault) {
+    menu.addItem({
+      command: 'gator-lab:remove-env',
+      args: { name: envName }
+    });
+    menu.addItem({
+      command: 'gator-lab:clone-env',
+      args: { name: envName }
+    });
+  }
   menu.addItem({
     command: 'gator-lab:export-env',
     args: { name: envName }
@@ -65,7 +72,7 @@ export const CondaEnvItem: React.FunctionComponent<IEnvItemProps> = (
     const x = rect?.left ?? event.clientX;
     const y = (rect?.bottom ?? event.clientY) + 4;
 
-    const menu = createMenu(props.commands, props.name);
+    const menu = createMenu(props.isDefault, props.commands, props.name);
     menu.open(x, y);
   };
 

--- a/packages/common/src/components/CondaEnvList.tsx
+++ b/packages/common/src/components/CondaEnvList.tsx
@@ -1,10 +1,8 @@
-/* eslint-disable react/prop-types */
 import * as React from 'react';
 import { style } from 'typestyle';
 import { CONDA_ENVIRONMENT_PANEL_ID } from '../constants';
 import { Conda } from '../tokens';
 import { CondaEnvItem } from './CondaEnvItem';
-import { CondaEnvToolBar, ENVIRONMENT_TOOLBAR_HEIGHT } from './CondaEnvToolBar';
 import { CommandRegistry } from '@lumino/commands';
 
 export const ENVIRONMENT_PANEL_WIDTH = 250;
@@ -34,13 +32,9 @@ export interface IEnvListProps {
    */
   onSelectedChange(name: string): void;
   /**
-   * Environment creation handler
+   * Environment creation dialog open handler
    */
-  onCreate(): void;
-  /**
-   * Environment import handler
-   */
-  onImport(): void;
+  onOpen(): void;
   commands: CommandRegistry;
 }
 
@@ -70,18 +64,7 @@ export const CondaEnvList: React.FunctionComponent<IEnvListProps> = (
 
   return (
     <div className={Style.Panel}>
-      <CondaEnvToolBar
-        isBase={isDefault}
-        isPending={props.isPending}
-        onCreate={props.onCreate}
-        onImport={props.onImport}
-      />
-      <div
-        id={CONDA_ENVIRONMENT_PANEL_ID}
-        className={Style.ListEnvs(
-          props.height - ENVIRONMENT_TOOLBAR_HEIGHT - 32
-        )}
-      >
+      <div id={CONDA_ENVIRONMENT_PANEL_ID} className={Style.ListEnvs}>
         {listItems}
       </div>
     </div>
@@ -98,11 +81,9 @@ namespace Style {
     width: ENVIRONMENT_PANEL_WIDTH
   });
 
-  export const ListEnvs = (height: number): string =>
-    style({
-      height: height,
-      overflowY: 'auto',
-      display: 'flex',
-      flexDirection: 'column'
-    });
+  export const ListEnvs = style({
+    overflowY: 'auto',
+    display: 'flex',
+    flexDirection: 'column'
+  });
 }

--- a/packages/common/src/components/CondaEnvList.tsx
+++ b/packages/common/src/components/CondaEnvList.tsx
@@ -52,14 +52,13 @@ export const CondaEnvList: React.FunctionComponent<IEnvListProps> = (
 ) => {
   let isDefault = false;
   const listItems = props.environments.map((env, idx) => {
-    const selected = env.name === props.selected;
-    if (selected) {
-      // Forbid clone and removing the environment named "base" (base conda environment)
-      // and the default one (i.e. the one containing JupyterLab)
-      isDefault = env.is_default || env.name === 'base';
-    }
+    // Forbid clone and removing the environment named "base" (base conda environment)
+    // and the default one (i.e. the one containing JupyterLab)
+    isDefault = env.is_default || env.name === 'base';
+
     return (
       <CondaEnvItem
+        isDefault={isDefault}
         name={env.name}
         key={env.name}
         selected={props.selected ? env.name === props.selected : false}

--- a/packages/common/src/components/CreateEnvButton.tsx
+++ b/packages/common/src/components/CreateEnvButton.tsx
@@ -1,0 +1,79 @@
+import { ToolbarButtonComponent } from '@jupyterlab/apputils';
+import { addIcon } from '@jupyterlab/ui-components';
+import * as React from 'react';
+import { style } from 'typestyle';
+
+//Toolbar height to align with package toolbar
+export const ENVIRONMENT_TOOLBAR_HEIGHT = 40;
+
+/**
+ * Environment panel toolbar properties
+ */
+export interface ICreateEnvButtonProps {
+  /**
+   * Open create environment dialog handler
+   */
+  onOpen(): void;
+}
+
+export const CreateEnvButton = (props: ICreateEnvButtonProps): JSX.Element => {
+  return (
+    <div className={`lm-Widget ${Style.EnvToolbar}`}>
+      <ToolbarButtonComponent
+        icon={addIcon}
+        tooltip="Create"
+        onClick={props.onOpen}
+        label="Create"
+        className={`${Style.CreateEnvIconLabelGap} ${Style.ToolbarButton}`}
+      />
+    </div>
+  );
+};
+
+namespace Style {
+  export const EnvToolbar = style({
+    display: 'flex',
+    alignItems: 'stretch',
+    justifyContent: 'center',
+    width: '100%'
+  });
+
+  export const ToolbarButton = style({
+    display: 'flex',
+    alignItems: 'stretch',
+    justifyContent: 'center',
+    width: '80%',
+    height: '90%',
+    boxSizing: 'border-box',
+    margin: 0,
+    background: 'var(--jp-layout-color1)',
+    border: '1px solid var(--jp-border-color2)',
+    borderRadius: '6px',
+    transition:
+      'background-color .15s ease, border-color .15s ease, box-shadow .15s ease',
+    $nest: {
+      '&.jp-ToolbarButtonComponent': { padding: 0 },
+      '&:hover': {
+        backgroundColor: 'var(--jp-layout-color2)',
+        borderColor: 'var(--jp-border-color1)',
+        boxShadow: '0 1px 2px rgba(0,0,0,0.08)'
+      },
+      '&:active': {
+        backgroundColor: 'var(--jp-layout-color3)'
+      },
+      '&:focus-visible': {
+        outline: '2px solid var(--jp-brand-color2)',
+        outlineOffset: '2px'
+      },
+      '.jp-Icon': { margin: 0 }
+    }
+  });
+
+  export const CreateEnvIconLabelGap = style({
+    $nest: {
+      '.jp-ToolbarButtonComponent-label': {
+        marginLeft: '6px'
+      }
+    }
+  });
+}

--- a/packages/common/src/components/CreateEnvDialog.tsx
+++ b/packages/common/src/components/CreateEnvDialog.tsx
@@ -1,5 +1,5 @@
 import { Dialog, ReactWidget } from '@jupyterlab/apputils';
-import { fileUploadIcon, addIcon } from '@jupyterlab/ui-components'; // TODO: editIcon
+import { fileUploadIcon, editIcon } from '@jupyterlab/ui-components'; // TODO: editIcon
 import * as React from 'react';
 
 /** dialog return options */
@@ -29,15 +29,12 @@ class CreateEnvironment extends React.PureComponent<{
       }, 50);
     });
 
-    // Add targeted global handler that only works when dialog is open
     const handleGlobalKeyDown = (event: KeyboardEvent) => {
-      // Only handle events if the dialog is actually open
       const dialogElement = document.querySelector('.jp-NbConda-CreateDialog');
       if (!dialogElement) {
-        return; // Dialog not open, ignore all events
+        return;
       }
 
-      // Only handle events within the dialog
       if (!dialogElement.contains(event.target as Node)) {
         return;
       }
@@ -117,7 +114,7 @@ class CreateEnvironment extends React.PureComponent<{
             aria-label="Create environment manually"
           >
             <div className="gator-OptionIcon">
-              <addIcon.react tag="span" />
+              <editIcon.react tag="span" />
             </div>
             <div className="gator-OptionText">Create Manually</div>
           </button>

--- a/packages/common/src/components/CreateEnvDialog.tsx
+++ b/packages/common/src/components/CreateEnvDialog.tsx
@@ -1,0 +1,79 @@
+import { ToolbarButtonComponent } from '@jupyterlab/apputils';
+import { addIcon } from '@jupyterlab/ui-components';
+import * as React from 'react';
+import { style } from 'typestyle';
+
+//Toolbar height to align with package toolbar
+export const ENVIRONMENT_TOOLBAR_HEIGHT = 40;
+
+/**
+ * Environment panel toolbar properties
+ */
+export interface ICreateEnvDialogProps {
+  /**
+   * Open create environment dialog handler
+   */
+  onOpen(): void;
+}
+
+export const CreateEnvDialog = (props: ICreateEnvDialogProps): JSX.Element => {
+  return (
+    <div className={`lm-Widget ${Style.EnvToolbar}`}>
+      <ToolbarButtonComponent
+        icon={addIcon}
+        tooltip="Create"
+        onClick={props.onOpen}
+        label="Create"
+        className={`${Style.CreateEnvIconLabelGap} ${Style.ToolbarButton}`}
+      />
+    </div>
+  );
+};
+
+namespace Style {
+  export const EnvToolbar = style({
+    display: 'flex',
+    alignItems: 'stretch',
+    justifyContent: 'center',
+    width: '100%'
+  });
+
+  export const ToolbarButton = style({
+    display: 'flex',
+    alignItems: 'stretch',
+    justifyContent: 'center',
+    width: '80%',
+    height: '90%',
+    boxSizing: 'border-box',
+    margin: 0,
+    background: 'var(--jp-layout-color1)',
+    border: '1px solid var(--jp-border-color2)',
+    borderRadius: '6px',
+    transition:
+      'background-color .15s ease, border-color .15s ease, box-shadow .15s ease',
+    $nest: {
+      '&.jp-ToolbarButtonComponent': { padding: 0 },
+      '&:hover': {
+        backgroundColor: 'var(--jp-layout-color2)',
+        borderColor: 'var(--jp-border-color1)',
+        boxShadow: '0 1px 2px rgba(0,0,0,0.08)'
+      },
+      '&:active': {
+        backgroundColor: 'var(--jp-layout-color3)'
+      },
+      '&:focus-visible': {
+        outline: '2px solid var(--jp-brand-color2)',
+        outlineOffset: '2px'
+      },
+      '.jp-Icon': { margin: 0 }
+    }
+  });
+
+  export const CreateEnvIconLabelGap = style({
+    $nest: {
+      '.jp-ToolbarButtonComponent-label': {
+        marginLeft: '6px'
+      }
+    }
+  });
+}

--- a/packages/common/src/components/CreateEnvDialog.tsx
+++ b/packages/common/src/components/CreateEnvDialog.tsx
@@ -9,6 +9,7 @@ class CreateEnvironment extends React.PureComponent<{
   onChoose: (c: Exclude<CreateChoice, 'cancel'>) => void;
 }> {
   private importButtonRef = React.createRef<HTMLButtonElement>();
+  private globalKeyHandler?: (event: KeyboardEvent) => void;
   private handleKeyDown = (
     event: React.KeyboardEvent,
     choice: Exclude<CreateChoice, 'cancel'>

--- a/packages/common/src/components/CreateEnvDialog.tsx
+++ b/packages/common/src/components/CreateEnvDialog.tsx
@@ -1,5 +1,5 @@
 import { Dialog, ReactWidget } from '@jupyterlab/apputils';
-import { fileUploadIcon, editIcon } from '@jupyterlab/ui-components'; // TODO: editIcon
+import { fileUploadIcon, editIcon } from '@jupyterlab/ui-components';
 import * as React from 'react';
 
 /** dialog return options */

--- a/packages/common/src/components/CreateEnvDialog.tsx
+++ b/packages/common/src/components/CreateEnvDialog.tsx
@@ -98,6 +98,7 @@ class CreateEnvironment extends React.PureComponent<{
             tabIndex={0}
             type="button"
             aria-label="Import environment from file"
+            data-choice="import"
           >
             <div className="gator-OptionIcon">
               <fileUploadIcon.react tag="span" />

--- a/packages/common/src/components/CreateEnvDialog.tsx
+++ b/packages/common/src/components/CreateEnvDialog.tsx
@@ -75,16 +75,12 @@ class CreateEnvironment extends React.PureComponent<{
 
     document.addEventListener('keydown', handleGlobalKeyDown, true);
 
-    (this as any)._globalKeyHandler = handleGlobalKeyDown;
+    this.globalKeyHandler = handleGlobalKeyDown;
   }
 
   componentWillUnmount() {
-    if ((this as any)._globalKeyHandler) {
-      document.removeEventListener(
-        'keydown',
-        (this as any)._globalKeyHandler,
-        true
-      );
+    if (this.globalKeyHandler) {
+      document.removeEventListener('keydown', this.globalKeyHandler, true);
     }
   }
   render() {

--- a/packages/common/src/components/CreateEnvDialog.tsx
+++ b/packages/common/src/components/CreateEnvDialog.tsx
@@ -5,6 +5,14 @@ import * as React from 'react';
 /** dialog return options */
 export type CreateChoice = 'import' | 'manual' | 'cancel';
 
+function creationChoice(element: HTMLElement) {
+  const choice = element.getAttribute('data-choice');
+  if (choice === 'import') {
+    return 'import';
+  } else {
+    return 'manual';
+  }
+}
 class CreateEnvironment extends React.PureComponent<{
   onChoose: (c: Exclude<CreateChoice, 'cancel'>) => void;
 }> {
@@ -45,11 +53,8 @@ class CreateEnvironment extends React.PureComponent<{
         if (event.key === 'Enter') {
           event.preventDefault();
           event.stopPropagation();
-          if (target.getAttribute('aria-label')?.includes('Import')) {
-            this.props.onChoose('import');
-          } else if (target.getAttribute('aria-label')?.includes('Create')) {
-            this.props.onChoose('manual');
-          }
+          const choice = creationChoice(target);
+          this.props.onChoose(choice);
         }
         return;
       }

--- a/packages/common/src/components/CreateEnvDialog.tsx
+++ b/packages/common/src/components/CreateEnvDialog.tsx
@@ -113,6 +113,7 @@ class CreateEnvironment extends React.PureComponent<{
             tabIndex={0}
             type="button"
             aria-label="Create environment manually"
+            data-choice="manual"
           >
             <div className="gator-OptionIcon">
               <editIcon.react tag="span" />

--- a/packages/common/src/components/NbConda.tsx
+++ b/packages/common/src/components/NbConda.tsx
@@ -5,6 +5,8 @@ import * as React from 'react';
 import { style } from 'typestyle';
 import { Conda, IEnvironmentManager } from '../tokens';
 import { CondaEnvList, ENVIRONMENT_PANEL_WIDTH } from './CondaEnvList';
+import { PACKAGE_TOOLBAR_HEIGHT } from './CondaPkgToolBar';
+import { CreateEnvDialog } from './CreateEnvDialog';
 import { CondaPkgPanel } from './CondaPkgPanel';
 import { ToolbarButtonComponent } from '@jupyterlab/ui-components';
 import { syncAltIcon } from '../icon';
@@ -65,6 +67,7 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
     this.handleCreateEnvironment = this.handleCreateEnvironment.bind(this);
     this.handleImportEnvironment = this.handleImportEnvironment.bind(this);
     this.handleRefreshEnvironment = this.handleRefreshEnvironment.bind(this);
+    this.handleOpenCreateEnvDialog = this.handleOpenCreateEnvDialog.bind(this);
 
     this.props.model.refreshEnvs.connect(() => {
       this.loadEnvironments();
@@ -82,6 +85,50 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
       currentEnvironment: name,
       channels: await this.props.model.getChannels(name)
     });
+  }
+
+  async handleOpenCreateEnvDialog(): Promise<void> {
+    this.handleNewEnvironment();
+  }
+
+  async handleNewEnvironment(): Promise<void> {
+    const toastId = '';
+    try {
+      const body = document.createElement('div');
+      const result = await showDialog({
+        title: 'New Environment',
+        body: new Widget({ node: body }),
+        buttons: [
+          Dialog.createButton({ label: 'Create' }),
+          Dialog.okButton({ label: 'Import' }),
+          Dialog.cancelButton()
+        ]
+      });
+
+      if (result.button.accept && result.button.label === 'Create') {
+        await this.handleCreateEnvironment();
+      } else if (result.button.accept && result.button.label === 'Import') {
+        await this.handleImportEnvironment();
+      }
+    } catch (error) {
+      if (error !== 'cancelled') {
+        console.error(error);
+        if (toastId) {
+          Notification.update({
+            id: toastId,
+            message: (error as any).message,
+            type: 'error',
+            autoClose: false
+          });
+        } else {
+          Notification.error((error as any).message);
+        }
+      } else {
+        if (toastId) {
+          Notification.dismiss(toastId);
+        }
+      }
+    }
   }
 
   async handleCreateEnvironment(): Promise<void> {
@@ -265,35 +312,48 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
 
   render(): JSX.Element {
     return (
-      <div className={Style.HeaderContainer}>
-        <div className={Style.Grow}>
-          <div className={Style.Title}>Conda Environments</div>
-          <div className={Style.RefreshButton}>
-            <div
-              data-loading={this.state.isLoading}
-              className={Style.RefreshInner}
-            >
-              <ToolbarButtonComponent
-                icon={syncAltIcon}
-                tooltip="Refresh Environments"
-                onClick={this.handleRefreshEnvironment}
-                label="Refresh Environments"
-                className={Style.RefeshEnvsIconLabelGap}
-              />
+      <div>
+        <div className={Style.HeaderContainer}>
+          <div className={Style.Grow}>
+            <div className={Style.Title}>Conda Environments</div>
+            <div className={Style.RefreshButton}>
+              <div
+                data-loading={this.state.isLoading}
+                className={Style.RefreshInner}
+              >
+                <ToolbarButtonComponent
+                  icon={syncAltIcon}
+                  tooltip="Refresh Environments"
+                  onClick={this.handleRefreshEnvironment}
+                  label="Refresh Environments"
+                  className={Style.RefeshEnvsIconLabelGap}
+                />
+              </div>
             </div>
           </div>
         </div>
+
         <div className={Style.Panel}>
-          <CondaEnvList
-            height={this.props.height}
-            isPending={this.state.isLoading}
-            environments={this.state.environments}
-            selected={this.state.currentEnvironment}
-            onSelectedChange={this.handleEnvironmentChange}
-            onCreate={this.handleCreateEnvironment}
-            onImport={this.handleImportEnvironment}
-            commands={this.props.commands}
-          />
+          {/* LEFT COLUMN */}
+          <div className={Style.LeftPane}>
+            <div
+              className={`lm-Widget ${Style.LeftToolbar} ${Style.ToggleCreateEnvDialogButton}`}
+            >
+              <CreateEnvDialog onOpen={this.handleOpenCreateEnvDialog} />
+            </div>
+
+            <CondaEnvList
+              height={this.props.height - PACKAGE_TOOLBAR_HEIGHT}
+              isPending={this.state.isLoading}
+              environments={this.state.environments}
+              selected={this.state.currentEnvironment}
+              onSelectedChange={this.handleEnvironmentChange}
+              onOpen={this.handleOpenCreateEnvDialog}
+              commands={this.props.commands}
+            />
+          </div>
+
+          {/* RIGHT COLUMN */}
           <CondaPkgPanel
             height={this.props.height}
             width={this.props.width - ENVIRONMENT_PANEL_WIDTH}
@@ -354,6 +414,44 @@ namespace Style {
     $nest: {
       '.jp-ToolbarButtonComponent-label': {
         marginLeft: '6px'
+      }
+    }
+  });
+
+  export const LeftPane = style({
+    display: 'flex',
+    flexDirection: 'column',
+    width: ENVIRONMENT_PANEL_WIDTH,
+    minWidth: ENVIRONMENT_PANEL_WIDTH
+  });
+
+  export const LeftToolbar = style({
+    display: 'flex',
+    alignItems: 'stretch',
+    height: PACKAGE_TOOLBAR_HEIGHT,
+    flexShrink: 0
+  });
+
+  export const ToggleCreateEnvDialogButton = style({
+    flex: '1 1 auto',
+    width: '100%',
+    flexGrow: 1,
+    justifyContent: 'center',
+    minWidth: 0,
+    $nest: {
+      '& > .jp-ToolbarButtonComponent, & > jp-button.jp-ToolbarButtonComponent':
+        {
+          flex: '1 1 0% !important',
+          width: '100% !important',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          minWidth: 0
+        },
+      '& > .jp-ToolbarButtonComponent .jp-ToolbarButtonComponent-label': {
+        marginLeft: '6px',
+        overflow: 'hidden',
+        whiteSpace: 'nowrap'
       }
     }
   });

--- a/packages/common/src/components/NbConda.tsx
+++ b/packages/common/src/components/NbConda.tsx
@@ -6,10 +6,11 @@ import { style } from 'typestyle';
 import { Conda, IEnvironmentManager } from '../tokens';
 import { CondaEnvList, ENVIRONMENT_PANEL_WIDTH } from './CondaEnvList';
 import { PACKAGE_TOOLBAR_HEIGHT } from './CondaPkgToolBar';
-import { CreateEnvDialog } from './CreateEnvDialog';
+import { CreateEnvButton } from './CreateEnvButton';
 import { CondaPkgPanel } from './CondaPkgPanel';
 import { ToolbarButtonComponent } from '@jupyterlab/ui-components';
 import { syncAltIcon } from '../icon';
+import { openCreateEnvDialog } from './CreateEnvDialog';
 
 /**
  * Jupyter Conda Component properties
@@ -88,46 +89,13 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
   }
 
   async handleOpenCreateEnvDialog(): Promise<void> {
-    this.handleNewEnvironment();
-  }
-
-  async handleNewEnvironment(): Promise<void> {
-    const toastId = '';
-    try {
-      const body = document.createElement('div');
-      const result = await showDialog({
-        title: 'New Environment',
-        body: new Widget({ node: body }),
-        buttons: [
-          Dialog.createButton({ label: 'Create' }),
-          Dialog.okButton({ label: 'Import' }),
-          Dialog.cancelButton()
-        ]
-      });
-
-      if (result.button.accept && result.button.label === 'Create') {
-        await this.handleCreateEnvironment();
-      } else if (result.button.accept && result.button.label === 'Import') {
-        await this.handleImportEnvironment();
-      }
-    } catch (error) {
-      if (error !== 'cancelled') {
-        console.error(error);
-        if (toastId) {
-          Notification.update({
-            id: toastId,
-            message: (error as any).message,
-            type: 'error',
-            autoClose: false
-          });
-        } else {
-          Notification.error((error as any).message);
-        }
-      } else {
-        if (toastId) {
-          Notification.dismiss(toastId);
-        }
-      }
+    const choice = await openCreateEnvDialog();
+    if (choice === 'manual') {
+      this.handleCreateEnvironment();
+    } else if (choice === 'import') {
+      this.handleImportEnvironment();
+    } else {
+      return;
     }
   }
 
@@ -339,7 +307,7 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
             <div
               className={`lm-Widget ${Style.LeftToolbar} ${Style.ToggleCreateEnvDialogButton}`}
             >
-              <CreateEnvDialog onOpen={this.handleOpenCreateEnvDialog} />
+              <CreateEnvButton onOpen={this.handleOpenCreateEnvDialog} />
             </div>
 
             <CondaEnvList

--- a/packages/common/src/components/NbConda.tsx
+++ b/packages/common/src/components/NbConda.tsx
@@ -162,15 +162,19 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
     } catch (error) {
       if (error !== 'cancelled') {
         console.error(error);
+        const errorMessage =
+          error instanceof Error
+            ? error.message
+            : String(error) || 'An unknown error occurred';
         if (toastId) {
           Notification.update({
             id: toastId,
-            message: (error as any).message,
+            message: errorMessage,
             type: 'error',
             autoClose: false
           });
         } else {
-          Notification.error((error as any).message);
+          Notification.error(errorMessage);
         }
       } else {
         if (toastId) {
@@ -239,15 +243,19 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
     } catch (error) {
       if (error !== 'cancelled') {
         console.error(error);
+        const errorMessage =
+          error instanceof Error
+            ? error.message
+            : String(error) || 'An unknown error occurred';
         if (toastId) {
           Notification.update({
             id: toastId,
-            message: (error as any).message,
+            message: errorMessage,
             type: 'error',
             autoClose: false
           });
         } else {
-          Notification.error((error as any).message);
+          Notification.error(errorMessage);
         }
       } else {
         if (toastId) {

--- a/packages/common/style/index.css
+++ b/packages/common/style/index.css
@@ -130,6 +130,25 @@ div[data-loading="true"] > jp-button[title="Refresh Environments"] > svg {
   box-shadow: 0 1px 2px rgba(0,0,0,0.06);
 }
 
+.gator-OptionCard:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.12);
+  border-color: var(--jp-border-color1);
+}
+
+.gator-OptionCard:focus-visible {
+  outline: 2px solid var(--jp-brand-color2);
+  outline-offset: 2px;
+  transform: translateY(-1px);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.12);
+  border-color: var(--jp-brand-color2);
+}
+
+.gator-OptionCard:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+
 .gator-OptionIcon {
   flex-grow: 1;
   display: flex;

--- a/packages/common/style/index.css
+++ b/packages/common/style/index.css
@@ -90,3 +90,64 @@ button.jp-button-hide {
 div[data-loading="true"] > jp-button[title="Refresh Environments"] > svg {
   animation: gator-spin 1s linear infinite;
 }
+
+/* === Create Environment Styles === */
+.jp-NbConda-CreateDialog .jp-Dialog {
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 6px 20px rgba(0,0,0,0.18);
+  min-width: 500px;
+  max-width: 560px;
+}
+
+.jp-NbConda-CreateDialog .jp-Dialog-body {
+  background: var(--jp-layout-color2);
+  padding: 20px 24px 28px;
+}
+
+.gator-OptionGrid.gator-TwoOptions {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
+  justify-items: center;
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.gator-OptionCard {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  width: 140px;
+  height: 100px;
+  padding: 12px 8px;
+  background: var(--jp-layout-color1);
+  border: 1px solid var(--jp-border-color2);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.06);
+}
+
+.gator-OptionIcon {
+  flex-grow: 1;
+  display: flex;
+  align-items: center;
+}
+
+.gator-OptionIcon svg {
+  width: 24px !important;
+  height: 24px !important;
+  color: var(--jp-ui-font-color1);
+}
+
+.gator-OptionText {
+  margin-top: auto;
+  text-align: center;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.2;
+  color: var(--jp-ui-font-color1);
+}
+/* ==================================== */


### PR DESCRIPTION
This PR replaces the Conda environment Toolbar with a "Create" environment button component that displays a dialog component with options to "import" an environment and "create manually".
<img width="1250" height="532" alt="create button" src="https://github.com/user-attachments/assets/b3a34e96-7fad-403f-9b4c-00cb5cd616f6" />

