### PR TITLE
Fix scroll for environment list with minHeight

### DIFF
--- a/packages/common/src/components/CondaEnvList.tsx
+++ b/packages/common/src/components/CondaEnvList.tsx
@@ -96,7 +96,8 @@ namespace Style {
     display: 'flex',
     flexDirection: 'column',
     overflow: 'hidden',
-    width: ENVIRONMENT_PANEL_WIDTH
+    width: ENVIRONMENT_PANEL_WIDTH,
+    minHeight: 0
   });
 
   export const ListEnvs = (height: number): string =>
@@ -104,6 +105,7 @@ namespace Style {
       height: height,
       overflowY: 'auto',
       display: 'flex',
-      flexDirection: 'column'
+      flexDirection: 'column',
+      minHeight: 0
     });
 }

--- a/packages/common/src/components/NbConda.tsx
+++ b/packages/common/src/components/NbConda.tsx
@@ -312,13 +312,15 @@ namespace Style {
     width: '100%',
     display: 'flex',
     flexDirection: 'row',
-    borderCollapse: 'collapse'
+    borderCollapse: 'collapse',
+    minHeight: 0
   });
 
   export const HeaderContainer = style({
     display: 'flex',
     flexDirection: 'column',
-    gap: '6px'
+    gap: '6px',
+    minHeight: 0
   });
 
   export const Grow = style({


### PR DESCRIPTION
Adding `minHeight: 0` to parents of `CondaEnvList` allows that component to shrink below the content size and kick off the overflow behavior.