### PR TITLE
Default current environment to active environment

### DIFF
--- a/packages/common/src/components/CondaEnvItem.tsx
+++ b/packages/common/src/components/CondaEnvItem.tsx
@@ -73,6 +73,7 @@ export const CondaEnvItem: React.FunctionComponent<IEnvItemProps> = (
     <div
       className={props.selected ? Style.SelectedItem : Style.Item}
       onClick={handleItemClick}
+      data-environment-name={props.name}
     >
       <span>{props.name}</span>
       <div

--- a/packages/common/src/components/CondaEnvList.tsx
+++ b/packages/common/src/components/CondaEnvList.tsx
@@ -50,6 +50,23 @@ export interface IEnvListProps {
 export const CondaEnvList: React.FunctionComponent<IEnvListProps> = (
   props: IEnvListProps
 ) => {
+  const listRef = React.useRef<HTMLDivElement>(null);
+
+  // Scroll selected environment into view
+  React.useEffect(() => {
+    if (props.selected && listRef.current) {
+      const selectedElement = listRef.current.querySelector(
+        `[data-environment-name="${props.selected}"]`
+      );
+      if (selectedElement) {
+        selectedElement.scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest'
+        });
+      }
+    }
+  }, [props.selected]);
+
   let isDefault = false;
   const listItems = props.environments.map((env, idx) => {
     const selected = env.name === props.selected;
@@ -78,6 +95,7 @@ export const CondaEnvList: React.FunctionComponent<IEnvListProps> = (
         onImport={props.onImport}
       />
       <div
+        ref={listRef}
         id={CONDA_ENVIRONMENT_PANEL_ID}
         className={Style.ListEnvs(
           props.height - ENVIRONMENT_TOOLBAR_HEIGHT - 32

--- a/packages/common/src/components/CondaPkgPanel.tsx
+++ b/packages/common/src/components/CondaPkgPanel.tsx
@@ -30,6 +30,10 @@ export interface IPkgPanelProps {
    * Package manager for the selected environment
    */
   packageManager: Conda.IPackageManager;
+  /**
+   * Current environment name
+   */
+  environmentName?: string;
 }
 
 /**

--- a/packages/common/src/components/NbConda.tsx
+++ b/packages/common/src/components/NbConda.tsx
@@ -248,24 +248,12 @@ export class NbConda extends React.Component<ICondaEnvProps, ICondaEnvState> {
           environments: await this.props.model.environments
         };
 
-        let targetEnv: string | undefined =
-          this.props.envName || this.state.currentEnvironment;
-
-        if (!targetEnv) {
-          newState.environments.forEach(env => {
-            if (env.is_default) {
-              targetEnv = env.name;
-            }
-          });
-
-          // If no default environment found, fallback to base
-          if (!targetEnv) {
-            const baseEnv = newState.environments.find(
-              env => env.name === 'base'
-            );
-            targetEnv = baseEnv ? baseEnv.name : newState.environments[0]?.name;
-          }
-        }
+        const targetEnv: string | undefined =
+          this.props.envName ||
+          this.state.currentEnvironment ||
+          newState.environments.find(env => env.is_default)?.name ||
+          newState.environments.find(env => env.name === 'base')?.name ||
+          newState.environments[0]?.name;
 
         if (targetEnv && targetEnv !== this.state.currentEnvironment) {
           newState.currentEnvironment = targetEnv;


### PR DESCRIPTION
This PR adds auto-selects the currently active environment (the base environment as a fallback) so that when the extension loads, the currently active environment's packages will be loaded and displayed.

This is to avoid a blank packages section that remains until the user selects an environment and packages start being loaded.

When the extension is launched, the active environment is selected and the packages begin to be loaded.