### PR TITLE
Updating Python version for API Tests

### DIFF
--- a/mamba_gator/tests/test_api.py
+++ b/mamba_gator/tests/test_api.py
@@ -52,6 +52,8 @@ class JupyterCondaAPITest(ServerTest):
             self.wait_for_task(self.rm_env, new_name)
         self.env_names.append(new_name)
 
+        # TODO: Remove this once we have a way to test the environment creation with packages from different channels
+        # or once packages are available in the default channel
         return self.conda_api.post(
             ["environments"],
             body={"name": new_name, "packages": packages or ["python!=3.14.0"]},


### PR DESCRIPTION
Currently, this PR tests modifying the pins for package version used for API tests.

~The solution might involve updating CI workflows and potentially changes to environment creation in the tests.~