### PR TITLE
Default to display `installed` packages in environment's package list

### DIFF
--- a/packages/common/src/components/CondaPkgPanel.tsx
+++ b/packages/common/src/components/CondaPkgPanel.tsx
@@ -98,7 +98,7 @@ export class CondaPkgPanel extends React.Component<
       packages: [],
       selected: [],
       searchTerm: '',
-      activeFilter: PkgFilters.All
+      activeFilter: PkgFilters.Installed
     };
 
     this._model = this.props.packageManager;
@@ -308,7 +308,7 @@ export class CondaPkgPanel extends React.Component<
       this.setState({
         isApplyingChanges: false,
         selected: [],
-        activeFilter: PkgFilters.All
+        activeFilter: PkgFilters.Installed
       });
       this._updatePackages();
     }
@@ -342,7 +342,7 @@ export class CondaPkgPanel extends React.Component<
       this.setState({
         isApplyingChanges: false,
         selected: [],
-        activeFilter: PkgFilters.All
+        activeFilter: PkgFilters.Installed
       });
       this._updatePackages();
     }
@@ -390,9 +390,7 @@ export class CondaPkgPanel extends React.Component<
 
   render(): JSX.Element {
     let filteredPkgs: Conda.IPackage[] = [];
-    if (this.state.activeFilter === PkgFilters.All) {
-      filteredPkgs = this.state.packages;
-    } else if (this.state.activeFilter === PkgFilters.Installed) {
+    if (this.state.activeFilter === PkgFilters.Installed) {
       filteredPkgs = this.state.packages.filter(pkg => pkg.version_installed);
     } else if (this.state.activeFilter === PkgFilters.Available) {
       filteredPkgs = this.state.packages.filter(pkg => !pkg.version_installed);

--- a/packages/common/src/components/CondaPkgToolBar.tsx
+++ b/packages/common/src/components/CondaPkgToolBar.tsx
@@ -8,7 +8,6 @@ import { cartArrowDownIcon, externalLinkIcon, undoIcon } from '../icon';
 export const PACKAGE_TOOLBAR_HEIGHT = 40;
 
 export enum PkgFilters {
-  All = 'ALL',
   Installed = 'INSTALLED',
   Available = 'AVAILABLE',
   Updatable = 'UPDATABLE',
@@ -71,7 +70,6 @@ export const CondaPkgToolBar = (props: ICondaPkgToolBarProps): JSX.Element => {
           onChange={props.onCategoryChanged}
           aria-label="Package filter"
         >
-          <option value={PkgFilters.All}>All</option>
           <option value={PkgFilters.Installed}>Installed</option>
           <option value={PkgFilters.Available}>Not installed</option>
           <option value={PkgFilters.Updatable}>Updatable</option>


### PR DESCRIPTION
This PR is based off of #320, and sets the active filter to the `installed` packages, and removes the filter option to display `all` packages.