### PR TITLE
Add widget app shell id in navigator

### DIFF
--- a/packages/navigator/src/plugins/navigator/index.ts
+++ b/packages/navigator/src/plugins/navigator/index.ts
@@ -37,6 +37,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     content.title.caption = 'Conda Packages Manager';
     content.title.icon = condaIcon;
     const widget = new MainAreaWidget({ content: content });
+    widget.id = 'mamba-gator-navigator';
     registerEnvCommands(app.commands, model);
     widget.title.closable = false;
     app.shell.add(widget, 'main');


### PR DESCRIPTION
When running the standalone navigator app from `mamba_gator` installed from PyPI, the page is empty save for the header and the devtools console displays the following error: `installHook.js:1 Widgets added to app shell must have unique id property.`


To verify this fix I edited the source bundle with this single line of code added and confirmed that the components were successfully displayed.

Note: ~This issue was not apparent when running the standalone app from an editable install.~ I can't reproduce it with the PyPI install of version 6.0.2 but I thought it'd be nicer to explicitly add this semantic ID.