### PR TITLE
Workflow to add docs preview for PRs

### DIFF
--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -2,7 +2,7 @@ name: 'Add a documentation preview link to the PRs description'
 
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
 
 on:
   pull_request_target:


### PR DESCRIPTION
This PR uses `readthedocs/actions/preview@v1` to add a link to the PR's description when a PR modifies docs files... for easy reference.