### PR TITLE
Use normalized names to identify editable packages

### DIFF
--- a/mamba_gator/envmanager.py
+++ b/mamba_gator/envmanager.py
@@ -68,7 +68,7 @@ def normalize_pkg_info(s: Dict[str, Any]) -> Dict[str, Union[str, List[str]]]:
     }
 
 def normalize_name(name: str) -> str:
-    """Normalize package name for comparison (Normalized Names, PEP 503)."""
+    """Normalize package name listing for comparison between conda and pip."""
     return name.lower().replace("-", "_").replace(".", "_")
 
 


### PR DESCRIPTION
This PR adds a `normalize_name` method used when comparing names in order to properly apply `<develop>` as the  listed package channel name when an editable package is installed.