### PR TITLE
Refactor method for retrieving environment packages for fewer subprocess calls

### DIFF
--- a/mamba_gator/envmanager.py
+++ b/mamba_gator/envmanager.py
@@ -679,8 +679,8 @@ class EnvManager:
             normalized_pkg = normalize_pkg_info(package)
 
             # Check if this is a pip package installed in development mode
-            # Development mode packages have 'channel': '<develop>' in pip list output
-            # or are pip packages with editable installs
+            # PyPI packages with editable installs should be marked as '<develop>'
+            # Packages already marked as '<develop>' from conda list are preserved as-is
             if normalized_pkg.get("channel") == "pypi":
                 if normalize_name(normalized_pkg["name"]) in editable_pkg_names:
                     normalized_pkg["channel"] = "<develop>"


### PR DESCRIPTION
This PR is based off of #351 and refactors backend code to reduce the number of `pip list` from O(n) to 2 calls made in the `env_packages` method. This speeds up the package listing, getting packages populated in an environment much more quickly after a user makes a selection and fires the request.