### PR TITLE
Fix missing styling with two package list modes

### DIFF
--- a/packages/navigator/style/index.css
+++ b/packages/navigator/style/index.css
@@ -1,4 +1,5 @@
 @import url('~@jupyterlab/application/style/index.css');
+@import url('~@jupyterlab/apputils/style/index.css');
 @import url('~@jupyterlab/theme-light-extension/style/theme.css');
 @import url('~@mamba-org/gator-common/style/index.css');
 


### PR DESCRIPTION
This PR fixes the standalone navigator app's missing styles, which render the new package list modes "direct"/"batch"

*Before*
<img width="1249" height="748" alt="Screenshot 2025-12-13 at 10 25 49 AM" src="https://github.com/user-attachments/assets/01489129-8479-473a-bd87-329c468b7373" />


*After*
<img width="1251" height="749" alt="Screenshot 2025-12-13 at 10 25 34 AM" src="https://github.com/user-attachments/assets/2fa19077-43e1-41bc-a4e7-47a18e291342" />
