### PR TITLE
CI: Separate job for frontend unit tests & add concurrency check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,8 @@ jobs:
   test-frontend-unit:
     name: Frontend Unit Tests on JL ${{ matrix.jupyterlab-version }}
     runs-on: ubuntu-latest
+    # Note: Skipping setup-python - using runner's pre-installed Python for pip only.
+    # JupyterLab is installed just to get jlpm, not for Python code execution.
     strategy:
       matrix:
         jupyterlab-version: ['4.5']


### PR DESCRIPTION
This pull request updates the CI workflow in for extension tests to improve how frontend tests are run and organized. There is now a dedicated job for frontend unit tests (also related cleanup test steps)

* Added a new `test-frontend-unit` job to run frontend unit tests and linter checks independently (except for the integration test on Ubuntu).
* Added a placeholder (commented out) for a future Playwright E2E test job.
* Add concurrency check to cancel old jobs on a new push to branch other than main