### PR TITLE
Display package descriptions under package name

### DIFF
--- a/packages/common/src/components/CondaPkgList.tsx
+++ b/packages/common/src/components/CondaPkgList.tsx
@@ -571,7 +571,8 @@ namespace Style {
 
   export const Summary = style({
     fontSize: '0.85em',
-    color: 'var(--jp-ui-font-color2)',
+    color: 'var(--jp-ui-font-color1)',
+    opacity: 0.72,
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis'


### PR DESCRIPTION
This PR removes the Description column and displays the description underneath the package names

*Before*:
<img width="1251" height="749" alt="Screenshot 2025-12-13 at 10 25 34 AM" src="https://github.com/user-attachments/assets/3ee43485-0758-43d4-8d59-ac22399db54a" />


*After*:
<img width="976" height="352" alt="Screenshot 2025-12-15 at 1 27 05 PM" src="https://github.com/user-attachments/assets/fe124479-4398-4075-9f5c-a64c3b2e95e5" />
