### PR TITLE
Move the linting in `Frontend Unit Tests` job to before tests run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,14 +147,14 @@ jobs:
       - name: Install dependencies
         run: jlpm install
 
+      - name: Run linter
+        run: jlpm run eslint:check
+
       - name: Build packages
         run: jlpm run build
 
       - name: Run frontend tests
         run: jlpm run test
-
-      - name: Run linter
-        run: jlpm run eslint:check
 
   # TODO: Enable when adding Playwright E2E tests
   # test-frontend-e2e:


### PR DESCRIPTION
This PR moves the linting step of the `Frontend Unit Tests on JL` CI job, to before the build and frontend test steps in an effort to get feedback earlier on in the job about linter pass/fail.